### PR TITLE
Fix reading/writing of sparse histogram

### DIFF
--- a/src/hipscat/pixel_math/sparse_histogram.py
+++ b/src/hipscat/pixel_math/sparse_histogram.py
@@ -48,7 +48,8 @@ class SparseHistogram:
 
     def to_dense_file(self, file_name):
         """Persist the DENSE array to disk as a numpy array."""
-        np.save(file_name, self.to_array())
+        with open(file_name, "wb+") as file_handle:
+            file_handle.write(self.to_array().data)
 
     @classmethod
     def make_empty(cls, healpix_order=10):

--- a/tests/hipscat/pixel_math/test_sparse_histogram.py
+++ b/tests/hipscat/pixel_math/test_sparse_histogram.py
@@ -3,6 +3,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from numpy import frombuffer
 from scipy.sparse import csr_array
 
 import hipscat.pixel_math.healpix_shim as hp
@@ -27,9 +28,10 @@ def test_read_write_round_trip(tmp_path):
     npt.assert_array_equal(read_histogram.to_array(), histogram.to_array())
 
     # Write as a dense 1-d numpy array
-    file_name = tmp_path / "round_trip_dense.npy"
+    file_name = tmp_path / "round_trip_dense.npz"
     histogram.to_dense_file(file_name)
-    read_histogram = np.load(str(file_name))
+    with open(file_name, "rb") as file_handle:
+        read_histogram = frombuffer(file_handle.read(), dtype=np.int64)
     npt.assert_array_equal(read_histogram, histogram.to_array())
 
 


### PR DESCRIPTION
In https://github.com/astronomy-commons/hats/pull/376 I introduced some incorrect changes to the I/O of SparseHistogram dense arrays and it caused [unit tests](https://github.com/astronomy-commons/hipscat-import/actions/runs/11366954187/job/31618506766) to fail in hipscat-import. This fixes it.

- [ ] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation