### PR TITLE
Pin astropy temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
     "aiohttp", # http filesystem support
-    "astropy",
+    "astropy<6.1",
     "fsspec>=2023.10.0", # Used for abstract filesystems
     "healpy",
     "jproperties",


### PR DESCRIPTION
## Change Description

Recent changes in mocpy, cdshealpix, and astropy have introduced regressions. This pins the astropy version to an earlier one, while we attempt to release hats renaming changes.