### PR TITLE
Convenience method to estimate mindist for a given order.

### DIFF
--- a/src/hats/pixel_math/healpix_shim.py
+++ b/src/hats/pixel_math/healpix_shim.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import healpy as hp
 import numpy as np
 
@@ -187,3 +189,25 @@ def margin2order(margin_thr_arcmin: np.ndarray) -> np.ndarray:
     """
     avg_size_arcmin = mindist2avgsize(margin_thr_arcmin)
     return avgsize2order(avg_size_arcmin)
+
+
+def order2mindist(order: np.ndarray | int) -> np.ndarray | float:
+    """Get the estimated minimum distance between pixels at a given order.
+
+    We don't have the precise geometry of the healpix grid yet,
+    we are using average_size / mininimum_distance = 1.6
+    as a rough estimate.
+
+    Parameters
+    ----------
+    order : np.ndarray of int or a single scalar int
+        The healpix order
+
+    Returns
+    -------
+    np.ndarray of float or a single scalar float
+        The minimum distance between pixels in arcminutes
+    """
+    pixel_nside = order2nside(order)
+    pixel_avgsize = nside2resol(pixel_nside, arcmin=True)
+    return avgsize2mindist(pixel_avgsize)

--- a/tests/hats/pixel_math/test_healpix_shim.py
+++ b/tests/hats/pixel_math/test_healpix_shim.py
@@ -28,3 +28,12 @@ def test_margin2order():
     margin_thr_arcmin = np.array([1 / 60, 10 / 60, 1, 5, 60])
     orders = np.array([17, 13, 11, 8, 5])
     assert_array_equal(hps.margin2order(margin_thr_arcmin), orders)
+
+
+def test_order2mindist():
+    """Test order2mindist for some pre-computed values"""
+    orders = np.array([17, 13, 11, 8, 5])
+    min_distances = np.array([0.01677, 0.268, 1.07, 8.588, 68.7])
+    assert_allclose(hps.order2mindist(orders), min_distances, rtol=1e-2)
+
+    assert_allclose(hps.order2mindist(17), 0.01677, rtol=1e-2)


### PR DESCRIPTION
See https://github.com/astronomy-commons/lsdb/issues/408

This kind of calculation is performed in a few different places, and may eventually be replaced by a more precise minimum distance calculation.