### PR TITLE
Use numba jit compilation instead of precompilation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ build-backend = "setuptools.build_meta"
 write_to = "src/hats/_version.py"
 
 [tool.pytest.ini_options]
-timeout = 1
+timeout = 5
 testpaths = [
     "tests",
 ]

--- a/src/hats/pixel_math/margin_bounding.py
+++ b/src/hats/pixel_math/margin_bounding.py
@@ -90,7 +90,7 @@ def check_margin_bounds(r_asc, dec, pixel_order, pixel, margin_threshold, step=1
 
 
 # numba jit compiler doesn't count for coverage tests, so we'll set no cover.
-@njit("double(double[:], double[:], double)")
+@njit
 def _find_minimum_distance(separations, distances, margin_threshold):  # pragma: no cover
     """Find the minimum distance between a given datapoint and a healpixel"""
     minimum_index = np.argmin(separations)

--- a/src/hats/pixel_tree/moc_filter.py
+++ b/src/hats/pixel_tree/moc_filter.py
@@ -1,4 +1,3 @@
-import numba
 import numpy as np
 from mocpy import MOC
 from numba import njit

--- a/src/hats/pixel_tree/moc_filter.py
+++ b/src/hats/pixel_tree/moc_filter.py
@@ -26,12 +26,7 @@ def filter_by_moc(
     return PixelTree(tree.tree[tree_mask], tree.tree_order)
 
 
-@njit(
-    numba.bool_[::1](
-        numba.int64[:, :],
-        numba.uint64[:, :],
-    )
-)
+@njit
 def perform_filter_by_moc(
     tree: np.ndarray,
     moc: np.ndarray,

--- a/src/hats/pixel_tree/pixel_alignment.py
+++ b/src/hats/pixel_tree/pixel_alignment.py
@@ -141,7 +141,7 @@ def get_pixel_mapping_df(mapping: np.ndarray, map_order: int) -> pd.DataFrame:
 
 
 # pylint: disable=too-many-statements
-@njit(numba.int64[::1, :](numba.int64[:, :], numba.int64[:, :]))
+@njit
 def perform_inner_align_trees(
     left: np.ndarray,
     right: np.ndarray,
@@ -208,15 +208,7 @@ def perform_inner_align_trees(
     return mapping[:out_index].T
 
 
-@njit(
-    numba.types.void(
-        numba.int64,
-        numba.int64,
-        numba.int64[:],
-        numba.boolean,
-        numba.types.List(numba.int64[::1]),
-    )
-)
+@njit
 def _add_pixels_until(
     add_from: int,
     add_to: int,
@@ -259,15 +251,7 @@ def _add_pixels_until(
         add_from = add_from + pixel_size
 
 
-@njit(
-    numba.types.void(
-        numba.int64,
-        numba.int64[:, :],
-        numba.int64,
-        numba.boolean,
-        numba.types.List(numba.int64[::1]),
-    )
-)
+@njit
 def _add_remaining_pixels(
     added_until: int,
     pixel_list: np.ndarray,
@@ -303,7 +287,7 @@ def _add_remaining_pixels(
 
 
 # pylint: disable=too-many-statements
-@njit(numba.types.List(numba.int64[::1])(numba.int64[:, :], numba.int64[:, :], numba.boolean, numba.boolean))
+@njit
 def perform_align_trees(
     left: np.ndarray,
     right: np.ndarray,

--- a/src/hats/pixel_tree/pixel_alignment.py
+++ b/src/hats/pixel_tree/pixel_alignment.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List
 
-import numba
 import numpy as np
 import pandas as pd
 from mocpy import MOC

--- a/tests/hats/catalog/test_catalog.py
+++ b/tests/hats/catalog/test_catalog.py
@@ -495,6 +495,7 @@ def test_empty_directory(tmp_path, catalog_info_data):
     assert catalog.catalog_name == "test_name"
 
 
+@pytest.mark.timeout(5)
 def test_generate_negative_tree_pixels(small_sky_order1_catalog):
     """Test generate_negative_tree_pixels on a basic catalog."""
     expected_pixels = [
@@ -537,6 +538,7 @@ def test_generate_negative_tree_pixels_order_0(small_sky_catalog):
     assert negative_tree == expected_pixels
 
 
+@pytest.mark.timeout(5)
 def test_generate_negative_tree_pixels_multi_order(small_sky_order1_catalog):
     """Test generate_negative_tree_pixels on a catalog with
     missing pixels on multiple order.

--- a/tests/hats/catalog/test_catalog.py
+++ b/tests/hats/catalog/test_catalog.py
@@ -517,6 +517,7 @@ def test_generate_negative_tree_pixels(small_sky_order1_catalog):
     assert negative_tree == expected_pixels
 
 
+@pytest.mark.timeout(20)
 def test_generate_negative_tree_pixels_order_0(small_sky_catalog):
     """Test generate_negative_tree_pixels on a catalog with only order 0 pixels."""
     expected_pixels = [

--- a/tests/hats/catalog/test_catalog.py
+++ b/tests/hats/catalog/test_catalog.py
@@ -495,7 +495,7 @@ def test_empty_directory(tmp_path, catalog_info_data):
     assert catalog.catalog_name == "test_name"
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(20)
 def test_generate_negative_tree_pixels(small_sky_order1_catalog):
     """Test generate_negative_tree_pixels on a basic catalog."""
     expected_pixels = [

--- a/tests/hats/catalog/test_catalog.py
+++ b/tests/hats/catalog/test_catalog.py
@@ -167,7 +167,6 @@ def test_cone_filter_big(small_sky_order1_catalog):
     assert (1, 47) in filtered_catalog.pixel_tree
 
 
-@pytest.mark.timeout(5)
 def test_cone_filter_multiple_order(catalog_info):
     catalog_pixel_list = [
         HealpixPixel(6, 30),
@@ -539,7 +538,6 @@ def test_generate_negative_tree_pixels_order_0(small_sky_catalog):
     assert negative_tree == expected_pixels
 
 
-@pytest.mark.timeout(5)
 def test_generate_negative_tree_pixels_multi_order(small_sky_order1_catalog):
     """Test generate_negative_tree_pixels on a catalog with
     missing pixels on multiple order.

--- a/tests/hats/pixel_tree/test_pixel_alignment.py
+++ b/tests/hats/pixel_tree/test_pixel_alignment.py
@@ -271,7 +271,7 @@ def test_catalog_align_outer(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_outer
     assert alignment.moc == moc
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(20)
 def test_outer_align_start_0():
     left_tree = PixelTree.from_healpix([HealpixPixel(0, 0)])
     right_tree = PixelTree.from_healpix([HealpixPixel(1, 1)])

--- a/tests/hats/pixel_tree/test_pixel_alignment.py
+++ b/tests/hats/pixel_tree/test_pixel_alignment.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from hats.catalog import Catalog
 from hats.pixel_math import HealpixPixel
@@ -56,6 +57,7 @@ def test_pixel_tree_alignment_inner(pixel_tree_2, pixel_tree_3, aligned_trees_2_
     assert_mapping_matches_tree(alignment)
 
 
+@pytest.mark.timeout(5)
 def test_pixel_tree_alignment_left(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_left):
     alignment = align_trees(pixel_tree_2, pixel_tree_3, "left")
     assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_left)
@@ -269,6 +271,7 @@ def test_catalog_align_outer(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_outer
     assert alignment.moc == moc
 
 
+@pytest.mark.timeout(5)
 def test_outer_align_start_0():
     left_tree = PixelTree.from_healpix([HealpixPixel(0, 0)])
     right_tree = PixelTree.from_healpix([HealpixPixel(1, 1)])

--- a/tests/hats/pixel_tree/test_pixel_alignment.py
+++ b/tests/hats/pixel_tree/test_pixel_alignment.py
@@ -57,7 +57,6 @@ def test_pixel_tree_alignment_inner(pixel_tree_2, pixel_tree_3, aligned_trees_2_
     assert_mapping_matches_tree(alignment)
 
 
-@pytest.mark.timeout(5)
 def test_pixel_tree_alignment_left(pixel_tree_2, pixel_tree_3, aligned_trees_2_3_left):
     alignment = align_trees(pixel_tree_2, pixel_tree_3, "left")
     assert_trees_equal(alignment.pixel_tree, aligned_trees_2_3_left)


### PR DESCRIPTION
Removes type from njit decorators to compile just in time