### PR TITLE
Write point map with cdshealpix skymap

### DIFF
--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -212,15 +212,15 @@ def write_parquet_metadata(
     )
 
 
-def read_fits_image(map_file_pointer: str | Path | UPath):
+def read_fits_image(map_file_pointer: str | Path | UPath) -> np.ndarray:
     """Read the object spatial distribution information from a healpix FITS file.
 
     Args:
-        map_file_pointer: location of file to be written
+        map_file_pointer (path-like): location of file to be written
 
     Returns:
-        one-dimensional numpy array of integers where the value at each index corresponds
-        to the number of objects found at the healpix pixel.
+        one-dimensional numpy array of integers where the
+        value at each index corresponds to the number of objects found at the healpix pixel.
     """
     map_file_pointer = get_upath(map_file_pointer)
     return Skymap.from_fits(map_file_pointer).values

--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -217,7 +217,7 @@ def read_fits_image(map_file_pointer: str | Path | UPath) -> np.ndarray:
     """Read the object spatial distribution information from a healpix FITS file.
 
     Args:
-        map_file_pointer (path-like): location of file to be written
+        map_file_pointer (path-like): location of file to be read
 
     Returns:
         one-dimensional numpy array of integers where the

--- a/tests/hats/io/file_io/test_file_io.py
+++ b/tests/hats/io/file_io/test_file_io.py
@@ -2,15 +2,18 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from hats.io import paths
 from hats.io.file_io import (
     delete_file,
     load_csv_to_pandas,
     load_csv_to_pandas_generator,
     make_directory,
+    read_fits_image,
     read_parquet_dataset,
     read_parquet_file_to_pandas,
     remove_directory,
     write_dataframe_to_csv,
+    write_fits_image,
     write_string_to_file,
 )
 from hats.io.file_io.file_pointer import does_file_or_directory_exist
@@ -123,3 +126,12 @@ def test_read_parquet_dataset(small_sky_dir, small_sky_order1_dir):
     )
 
     assert ds.count_rows() == 131
+
+
+def test_write_point_map_roundtrip(small_sky_order1_dir, tmp_path):
+    """Test the reading/writing of a catalog point map"""
+    expected_counts_skymap = read_fits_image(paths.get_point_map_file_pointer(small_sky_order1_dir))
+    output_map_pointer = paths.get_point_map_file_pointer(tmp_path)
+    write_fits_image(expected_counts_skymap, output_map_pointer)
+    counts_skymap = read_fits_image(output_map_pointer)
+    np.testing.assert_array_equal(counts_skymap, expected_counts_skymap)


### PR DESCRIPTION
Migrate the `point_map.fits` I/O operations to use cdshealpix skymap methods. Closes #399.

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation