### PR TITLE
Try windows test workflow

### DIFF
--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r requirements.txt
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies and run tests in a Windows environment.
+# This is intended to catch any file-system specific issues, and so runs less
+# frequently than other test suites.
+
+name: Windows unit test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run unit tests with pytest
+      run: |
+        python -m pytest tests

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -28,7 +28,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-        pip install -r requirements.txt
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -11,7 +11,6 @@ import hats.pixel_math as hist
 import hats.pixel_math.healpix_shim as hp
 from hats.catalog import Catalog, PartitionInfo, TableProperties
 from hats.catalog.association_catalog.partition_join_info import PartitionJoinInfo
-from hats.io.paths import pixel_catalog_files
 from hats.pixel_math import HealpixPixel
 from hats.pixel_tree import PixelAlignment, align_trees
 from hats.pixel_tree.pixel_tree import PixelTree
@@ -65,9 +64,6 @@ class Suite:
 
     def time_outer_pixel_alignment(self):
         align_trees(self.pixel_tree_1, self.pixel_tree_2, alignment_type="outer")
-
-    def time_paths_creation(self):
-        pixel_catalog_files("foo/", self.pixel_list)
 
 
 class MetadataSuite:

--- a/tests/hats/io/file_io/test_file_io.py
+++ b/tests/hats/io/file_io/test_file_io.py
@@ -103,10 +103,10 @@ def test_load_csv_to_pandas_generator_encoding(tmp_path):
 
 
 def test_write_df_to_csv(tmp_path):
-    random_df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
+    random_df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD")).astype(int)
     test_file_path = tmp_path / "test.csv"
     write_dataframe_to_csv(random_df, test_file_path, index=False)
-    loaded_df = pd.read_csv(test_file_path)
+    loaded_df = pd.read_csv(test_file_path).astype(int)
     pd.testing.assert_frame_equal(loaded_df, random_df)
 
 

--- a/tests/hats/io/test_paths.py
+++ b/tests/hats/io/test_paths.py
@@ -59,24 +59,6 @@ def test_pixel_catalog_file_nonint():
         paths.pixel_catalog_file("/foo", "zero", "five")
 
 
-def test_pixel_catalog_files():
-    expected = [
-        os.path.join("foo", "dataset", "Norder=0", "Dir=0", "Npix=5.parquet"),
-        os.path.join("foo", "dataset", "Norder=1", "Dir=0", "Npix=16.parquet"),
-    ]
-    result = paths.pixel_catalog_files("foo", [HealpixPixel(0, 5), HealpixPixel(1, 16)])
-    assert expected == result
-
-
-def test_pixel_catalog_files_w_query_params():
-    expected = [
-        "https://foo/dataset/Norder=0/Dir=0/Npix=5.parquet?columns=ID%2CRA%2CDEC%2Cr_auto&filters=r_auto%3C13"
-    ]
-    query_params = {"columns": ["ID", "RA", "DEC", "r_auto"], "filters": ["r_auto<13"]}
-    result = paths.pixel_catalog_files("https://foo", [HealpixPixel(0, 5)], query_params=query_params)
-    assert expected == result
-
-
 def test_dict_to_query_urlparams():
     expected = "?columns=ID%2CRA%2CDEC%2Cr_auto&filters=r_auto%3C13"
     query_params = {"columns": ["ID", "RA", "DEC", "r_auto"], "filters": ["r_auto<13"]}

--- a/tests/hats/io/test_paths.py
+++ b/tests/hats/io/test_paths.py
@@ -61,10 +61,10 @@ def test_pixel_catalog_file_nonint():
 
 def test_pixel_catalog_files():
     expected = [
-        os.path.join(os.sep, "foo", "dataset", "Norder=0", "Dir=0", "Npix=5.parquet"),
-        os.path.join(os.sep, "foo", "dataset", "Norder=1", "Dir=0", "Npix=16.parquet"),
+        os.path.join("foo", "dataset", "Norder=0", "Dir=0", "Npix=5.parquet"),
+        os.path.join("foo", "dataset", "Norder=1", "Dir=0", "Npix=16.parquet"),
     ]
-    result = paths.pixel_catalog_files("/foo/", [HealpixPixel(0, 5), HealpixPixel(1, 16)])
+    result = paths.pixel_catalog_files("foo", [HealpixPixel(0, 5), HealpixPixel(1, 16)])
     assert expected == result
 
 

--- a/tests/hats/io/test_paths.py
+++ b/tests/hats/io/test_paths.py
@@ -1,5 +1,7 @@
 """Test pixel path creation"""
 
+import os
+
 import pytest
 
 from hats.io import paths
@@ -8,14 +10,14 @@ from hats.pixel_math.healpix_pixel import INVALID_PIXEL, HealpixPixel
 
 def test_pixel_directory():
     """Simple case with sensical inputs"""
-    expected = "/foo/dataset/Norder=0/Dir=0"
+    expected = os.path.join(os.sep, "foo", "dataset", "Norder=0", "Dir=0")
     result = paths.pixel_directory("/foo", 0, 5)
-    assert str(result) == expected
+    assert str(result) == str(expected)
 
 
 def test_pixel_directory_number():
     """Simple case with sensical inputs"""
-    expected = "/foo/dataset/Norder=0/Dir=0"
+    expected = os.path.join(os.sep, "foo", "dataset", "Norder=0", "Dir=0")
     result = paths.pixel_directory("/foo", pixel_order=0, pixel_number=5, directory_number=0)
     assert str(result) == expected
 
@@ -37,7 +39,7 @@ def test_pixel_directory_nonint():
 
 def test_pixel_catalog_file():
     """Simple case with sensical inputs"""
-    expected = "/foo/dataset/Norder=0/Dir=0/Npix=5.parquet"
+    expected = os.path.join(os.sep, "foo", "dataset", "Norder=0", "Dir=0", "Npix=5.parquet")
     result = paths.pixel_catalog_file("/foo", HealpixPixel(0, 5))
     assert str(result) == expected
 
@@ -58,7 +60,10 @@ def test_pixel_catalog_file_nonint():
 
 
 def test_pixel_catalog_files():
-    expected = ["/foo/dataset/Norder=0/Dir=0/Npix=5.parquet", "/foo/dataset/Norder=1/Dir=0/Npix=16.parquet"]
+    expected = [
+        os.path.join(os.sep, "foo", "dataset", "Norder=0", "Dir=0", "Npix=5.parquet"),
+        os.path.join(os.sep, "foo", "dataset", "Norder=1", "Dir=0", "Npix=16.parquet"),
+    ]
     result = paths.pixel_catalog_files("/foo/", [HealpixPixel(0, 5), HealpixPixel(1, 16)])
     assert expected == result
 
@@ -104,6 +109,9 @@ def test_get_healpix_from_path():
 
     # Test a few ways we could represent the path.
     result = paths.get_healpix_from_path("/foo/dataset/Norder=5/Dir=0/Npix=34.parquet")
+    assert result == expected
+
+    result = paths.get_healpix_from_path("C:\\foo\\dataset\\Norder=5\\Dir=0\\Npix=34.parquet")
     assert result == expected
 
     result = paths.get_healpix_from_path("Norder=5/Dir=0/Npix=34.pq")


### PR DESCRIPTION
Now that we don't depend on healpy, everything should run well on Windows. This adds a test to confirm that.

Modifies tests to not be posix-specific, and removes now-dead `pixel_catalog_files` method.