### PR TITLE
Remove typing imports for List, Tuple, Union

### DIFF
--- a/src/hats/catalog/association_catalog/association_catalog.py
+++ b/src/hats/catalog/association_catalog/association_catalog.py
@@ -6,7 +6,10 @@ from mocpy import MOC
 
 from hats.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hats.catalog.dataset.table_properties import TableProperties
-from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset, PixelInputTypes
+from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset
+from hats.catalog.partition_info import PartitionInfo
+from hats.pixel_math import HealpixPixel
+from hats.pixel_tree.pixel_tree import PixelTree
 
 
 class AssociationCatalog(HealpixDataset):
@@ -20,7 +23,7 @@ class AssociationCatalog(HealpixDataset):
     def __init__(
         self,
         catalog_info: TableProperties,
-        pixels: PixelInputTypes,
+        pixels: PartitionInfo | PixelTree | list[HealpixPixel],
         join_pixels: list | pd.DataFrame | PartitionJoinInfo,
         catalog_path=None,
         moc: MOC | None = None,

--- a/src/hats/catalog/association_catalog/association_catalog.py
+++ b/src/hats/catalog/association_catalog/association_catalog.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Union
-
 import pandas as pd
 import pyarrow as pa
 from mocpy import MOC
@@ -19,13 +17,11 @@ class AssociationCatalog(HealpixDataset):
     Catalog, corresponding to each pair of partitions in each catalog that contain rows to join.
     """
 
-    JoinPixelInputTypes = Union[list, pd.DataFrame, PartitionJoinInfo]
-
     def __init__(
         self,
         catalog_info: TableProperties,
         pixels: PixelInputTypes,
-        join_pixels: JoinPixelInputTypes,
+        join_pixels: list | pd.DataFrame | PartitionJoinInfo,
         catalog_path=None,
         moc: MOC | None = None,
         schema: pa.Schema | None = None,
@@ -44,7 +40,7 @@ class AssociationCatalog(HealpixDataset):
 
     @staticmethod
     def _get_partition_join_info_from_pixels(
-        join_pixels: JoinPixelInputTypes,
+        join_pixels: list | pd.DataFrame | PartitionJoinInfo,
     ) -> PartitionJoinInfo:
         if isinstance(join_pixels, PartitionJoinInfo):
             return join_pixels

--- a/src/hats/catalog/association_catalog/partition_join_info.py
+++ b/src/hats/catalog/association_catalog/partition_join_info.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import Dict, List
 
 import numpy as np
 import pandas as pd
@@ -46,7 +45,7 @@ class PartitionJoinInfo:
             if column not in self.data_frame.columns:
                 raise ValueError(f"join_info_df does not contain column {column}")
 
-    def primary_to_join_map(self) -> Dict[HealpixPixel, List[HealpixPixel]]:
+    def primary_to_join_map(self) -> dict[HealpixPixel, list[HealpixPixel]]:
         """Generate a map from a single primary pixel to one or more pixels in the join catalog.
 
         Lots of cute comprehension is happening here, so watch out!

--- a/src/hats/catalog/catalog.py
+++ b/src/hats/catalog/catalog.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List
-
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset
 from hats.pixel_math import HealpixPixel
 from hats.pixel_tree.negative_tree import compute_negative_tree_pixels
@@ -17,7 +15,7 @@ class Catalog(HealpixDataset):
     `Norder=/Dir=/Npix=.parquet`
     """
 
-    def generate_negative_tree_pixels(self) -> List[HealpixPixel]:
+    def generate_negative_tree_pixels(self) -> list[HealpixPixel]:
         """Get the leaf nodes at each healpix order that have zero catalog data.
 
         For example, if an example catalog only had data points in pixel 0 at

--- a/src/hats/catalog/dataset/dataset.py
+++ b/src/hats/catalog/dataset/dataset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
 
 import pyarrow as pa
 from upath import UPath
@@ -41,8 +40,8 @@ class Dataset:
     def aggregate_column_statistics(
         self,
         exclude_hats_columns: bool = True,
-        exclude_columns: List[str] = None,
-        include_columns: List[str] = None,
+        exclude_columns: list[str] = None,
+        include_columns: list[str] = None,
     ):
         """Read footer statistics in parquet metadata, and report on global min/max values.
 

--- a/src/hats/catalog/dataset/table_properties.py
+++ b/src/hats/catalog/dataset/table_properties.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, Optional
 
 from jproperties import Properties
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
@@ -90,7 +90,7 @@ class TableProperties(BaseModel):
 
     ra_column: Optional[str] = Field(default=None, alias="hats_col_ra")
     dec_column: Optional[str] = Field(default=None, alias="hats_col_dec")
-    default_columns: Optional[List[str]] = Field(default=None, alias="hats_cols_default")
+    default_columns: Optional[list[str]] = Field(default=None, alias="hats_cols_default")
     """Which columns should be read from parquet files, when user doesn't otherwise specify."""
 
     primary_catalog: Optional[str] = Field(default=None, alias="hats_primary_table_url")
@@ -120,7 +120,7 @@ class TableProperties(BaseModel):
     indexing_column: Optional[str] = Field(default=None, alias="hats_index_column")
     """Column that we provide an index over."""
 
-    extra_columns: Optional[List[str]] = Field(default=None, alias="hats_index_extra_column")
+    extra_columns: Optional[list[str]] = Field(default=None, alias="hats_index_extra_column")
     """Any additional payload columns included in index."""
 
     ## Allow any extra keyword args to be stored on the properties object.
@@ -128,7 +128,7 @@ class TableProperties(BaseModel):
 
     @field_validator("default_columns", "extra_columns", mode="before")
     @classmethod
-    def space_delimited_list(cls, str_value: str) -> List[str]:
+    def space_delimited_list(cls, str_value: str) -> list[str]:
         """Convert a space-delimited list string into a python list of strings."""
         if isinstance(str_value, str):
             # Split on a few kinds of delimiters (just to be safe), and remove duplicates
@@ -193,7 +193,7 @@ class TableProperties(BaseModel):
         return formatted_string
 
     @classmethod
-    def read_from_dir(cls, catalog_dir: Union[str, Path, UPath]) -> Self:
+    def read_from_dir(cls, catalog_dir: str | Path | UPath) -> Self:
         """Read field values from a java-style properties file."""
         file_path = file_io.get_upath(catalog_dir) / "properties"
         if not file_io.does_file_or_directory_exist(file_path):
@@ -203,7 +203,7 @@ class TableProperties(BaseModel):
             p.load(f, "utf-8")
         return cls(**p.properties)
 
-    def to_properties_file(self, catalog_dir: Union[str, Path, UPath]) -> Self:
+    def to_properties_file(self, catalog_dir: str | Path | UPath) -> Self:
         """Write fields to a java-style properties file."""
         # pylint: disable=protected-access
         parameters = self.model_dump(by_alias=True, exclude_none=True)

--- a/src/hats/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hats/catalog/healpix_dataset/healpix_dataset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Tuple, Union
 
 import astropy.units as u
 import numpy as np
@@ -30,8 +29,6 @@ from hats.pixel_tree.moc_filter import filter_by_moc
 from hats.pixel_tree.pixel_alignment import align_with_mocs
 from hats.pixel_tree.pixel_tree import PixelTree
 
-PixelInputTypes = Union[PartitionInfo, PixelTree, List[HealpixPixel]]
-
 
 class HealpixDataset(Dataset):
     """A HATS dataset partitioned with a HEALPix partitioning structure.
@@ -45,7 +42,7 @@ class HealpixDataset(Dataset):
     def __init__(
         self,
         catalog_info: TableProperties,
-        pixels: PixelInputTypes,
+        pixels: PartitionInfo | PixelTree | list[HealpixPixel],
         catalog_path: str | Path | UPath | None = None,
         moc: MOC | None = None,
         schema: pa.Schema | None = None,
@@ -66,7 +63,7 @@ class HealpixDataset(Dataset):
         self.pixel_tree = self._get_pixel_tree_from_pixels(pixels)
         self.moc = moc
 
-    def get_healpix_pixels(self) -> List[HealpixPixel]:
+    def get_healpix_pixels(self) -> list[HealpixPixel]:
         """Get healpix pixel objects for all pixels contained in the catalog.
 
         Returns:
@@ -75,7 +72,9 @@ class HealpixDataset(Dataset):
         return self.partition_info.get_healpix_pixels()
 
     @staticmethod
-    def _get_partition_info_from_pixels(pixels: PixelInputTypes) -> PartitionInfo:
+    def _get_partition_info_from_pixels(
+        pixels: PartitionInfo | PixelTree | list[HealpixPixel],
+    ) -> PartitionInfo:
         if isinstance(pixels, PartitionInfo):
             return pixels
         if isinstance(pixels, PixelTree):
@@ -85,7 +84,7 @@ class HealpixDataset(Dataset):
         raise TypeError("Pixels must be of type PartitionInfo, PixelTree, or List[HealpixPixel]")
 
     @staticmethod
-    def _get_pixel_tree_from_pixels(pixels: PixelInputTypes) -> PixelTree:
+    def _get_pixel_tree_from_pixels(pixels: PartitionInfo | PixelTree | list[HealpixPixel]) -> PixelTree:
         if isinstance(pixels, PartitionInfo):
             return PixelTree.from_healpix(pixels.get_healpix_pixels())
         if isinstance(pixels, PixelTree):
@@ -118,7 +117,7 @@ class HealpixDataset(Dataset):
         )
         return max_order
 
-    def filter_from_pixel_list(self, pixels: List[HealpixPixel]) -> Self:
+    def filter_from_pixel_list(self, pixels: list[HealpixPixel]) -> Self:
         """Filter the pixels in the catalog to only include any that overlap with the requested pixels.
 
         Args:
@@ -155,7 +154,7 @@ class HealpixDataset(Dataset):
         )
         return self.filter_by_moc(cone_moc)
 
-    def filter_by_box(self, ra: Tuple[float, float], dec: Tuple[float, float]) -> Self:
+    def filter_by_box(self, ra: tuple[float, float], dec: tuple[float, float]) -> Self:
         """Filter the pixels in the catalog to only include the pixels that overlap with a
         zone, defined by right ascension and declination ranges. The right ascension edges follow
         great arc circles and the declination edges follow small arc circles.

--- a/src/hats/catalog/index/index_catalog.py
+++ b/src/hats/catalog/index/index_catalog.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import numpy as np
 import pyarrow.compute as pc
 import pyarrow.dataset as pds
@@ -16,7 +14,7 @@ class IndexCatalog(Dataset):
     Note that this is not a true "HATS Catalog", as it is not partitioned spatially.
     """
 
-    def loc_partitions(self, ids) -> List[HealpixPixel]:
+    def loc_partitions(self, ids) -> list[HealpixPixel]:
         """Find the set of partitions in the primary catalog for the ids provided.
 
         Args:

--- a/src/hats/catalog/partition_info.py
+++ b/src/hats/catalog/partition_info.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -27,11 +26,11 @@ class PartitionInfo:
     METADATA_ORDER_COLUMN_NAME = "Norder"
     METADATA_PIXEL_COLUMN_NAME = "Npix"
 
-    def __init__(self, pixel_list: List[HealpixPixel], catalog_base_dir: str = None) -> None:
+    def __init__(self, pixel_list: list[HealpixPixel], catalog_base_dir: str = None) -> None:
         self.pixel_list = pixel_list
         self.catalog_base_dir = catalog_base_dir
 
-    def get_healpix_pixels(self) -> List[HealpixPixel]:
+    def get_healpix_pixels(self) -> list[HealpixPixel]:
         """Get healpix pixel objects for all pixels represented as partitions.
 
         Returns:
@@ -158,7 +157,7 @@ class PartitionInfo:
     @classmethod
     def _read_from_metadata_file(
         cls, metadata_file: str | Path | UPath, strict: bool = False
-    ) -> List[HealpixPixel]:
+    ) -> list[HealpixPixel]:
         """Read partition info list from a `_metadata` file.
 
         Args:
@@ -260,7 +259,7 @@ class PartitionInfo:
         return pd.DataFrame.from_dict(partition_info_dict)
 
     @classmethod
-    def from_healpix(cls, healpix_pixels: List[HealpixPixel]) -> PartitionInfo:
+    def from_healpix(cls, healpix_pixels: list[HealpixPixel]) -> PartitionInfo:
         """Create a partition info object from a list of constituent healpix pixels.
 
         Args:

--- a/src/hats/inspection/almanac.py
+++ b/src/hats/inspection/almanac.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import warnings
-from typing import List
 
 import pandas as pd
 
@@ -218,7 +217,7 @@ class Almanac:
                 return None
         return self.entries[resolved_name]
 
-    def catalogs(self, include_deprecated=False, types: List[str] | None = None):
+    def catalogs(self, include_deprecated=False, types: list[str] | None = None):
         """Get names of catalogs in the almanac, matching the provided conditions.
 
         Catalogs must meet all criteria provided in order to be returned (e.g.

--- a/src/hats/inspection/almanac_info.py
+++ b/src/hats/inspection/almanac_info.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import List
 
 import yaml
 from typing_extensions import Self
@@ -24,14 +23,14 @@ class AlmanacInfo:
     join: str | None = None
     primary_link: Self | None = None
     join_link: Self | None = None
-    sources: List[Self] = field(default_factory=list)
-    objects: List[Self] = field(default_factory=list)
-    margins: List[Self] = field(default_factory=list)
-    associations: List[Self] = field(default_factory=list)
-    associations_right: List[Self] = field(default_factory=list)
-    indexes: List[Self] = field(default_factory=list)
+    sources: list[Self] = field(default_factory=list)
+    objects: list[Self] = field(default_factory=list)
+    margins: list[Self] = field(default_factory=list)
+    associations: list[Self] = field(default_factory=list)
+    associations_right: list[Self] = field(default_factory=list)
+    indexes: list[Self] = field(default_factory=list)
 
-    creators: List[str] = field(default_factory=list)
+    creators: list[str] = field(default_factory=list)
     description: str = ""
     version: str = ""
     deprecated: str = ""

--- a/src/hats/inspection/visualize_catalog.py
+++ b/src/hats/inspection/visualize_catalog.py
@@ -6,7 +6,7 @@ NB: Testing validity of generated plots is currently not tested in our unit test
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Dict, List, Tuple, Type
+from typing import TYPE_CHECKING, Type
 
 import astropy.units as u
 import astropy.wcs
@@ -106,7 +106,7 @@ def plot_pixels(catalog: HealpixDataset, plot_title: str | None = None, **kwargs
 
 
 def plot_pixel_list(
-    pixels: List[HealpixPixel], plot_title: str = "", projection="MOL", color_by_order=True, **kwargs
+    pixels: list[HealpixPixel], plot_title: str = "", projection="MOL", color_by_order=True, **kwargs
 ):
     """Create a visual map of the pixel density of a list of pixels.
 
@@ -143,14 +143,14 @@ def plot_moc(
     *,
     projection: str = "MOL",
     title: str = "",
-    fov: Quantity | Tuple[Quantity, Quantity] = None,
+    fov: Quantity | tuple[Quantity, Quantity] = None,
     center: SkyCoord | None = None,
     wcs: astropy.wcs.WCS = None,
     frame_class: Type[BaseFrame] | None = None,
     ax: WCSAxes | None = None,
     fig: Figure | None = None,
     **kwargs,
-) -> Tuple[Figure, WCSAxes]:
+) -> tuple[Figure, WCSAxes]:
     """Plots a moc
 
     By default, a new matplotlib figure and axis will be created, and the projection will be a Molleweide
@@ -251,7 +251,7 @@ def get_fov_moc_from_wcs(wcs: WCS) -> MOC | None:
     return moc_viewport
 
 
-def cull_to_fov(depth_ipix_d: Dict[int, Tuple[np.ndarray, np.ndarray]], wcs):
+def cull_to_fov(depth_ipix_d: dict[int, tuple[np.ndarray, np.ndarray]], wcs):
     """Culls a mapping of ipix to values to pixels that are inside the plot window defined by a WCS
 
     Modified from mocpy.moc.plot.utils.build_plotting_moc
@@ -291,7 +291,7 @@ def cull_to_fov(depth_ipix_d: Dict[int, Tuple[np.ndarray, np.ndarray]], wcs):
     return output_dict
 
 
-def _merge_too_small_pixels(depth_ipix_d: Dict[int, Tuple[np.ndarray, np.ndarray]], wcs):
+def _merge_too_small_pixels(depth_ipix_d: dict[int, tuple[np.ndarray, np.ndarray]], wcs):
     """Merges any pixels too small in a map to a lower order, with the map values within a lower order pixel
     being sampled"""
     # Get the WCS cdelt giving the deg.px^(-1) resolution.
@@ -331,7 +331,7 @@ def _merge_too_small_pixels(depth_ipix_d: Dict[int, Tuple[np.ndarray, np.ndarray
     return depth_ipix_d
 
 
-def cull_from_pixel_map(depth_ipix_d: Dict[int, Tuple[np.ndarray, np.ndarray]], wcs, max_split_depth=7):
+def cull_from_pixel_map(depth_ipix_d: dict[int, tuple[np.ndarray, np.ndarray]], wcs, max_split_depth=7):
     """Modified from mocpy.moc.plot.culling_backfacing_cells.from_moc
 
     Create a new MOC that do not contain the HEALPix cells that are backfacing the projection.
@@ -453,7 +453,7 @@ def plot_healpix_map(
     ipix: np.ndarray | None = None,
     depth: np.ndarray | None = None,
     cbar: bool = True,
-    fov: Quantity | Tuple[Quantity, Quantity] = None,
+    fov: Quantity | tuple[Quantity, Quantity] = None,
     center: SkyCoord | None = None,
     wcs: astropy.wcs.WCS = None,
     frame_class: Type[BaseFrame] | None = None,
@@ -536,7 +536,7 @@ def plot_healpix_map(
 
 def initialize_wcs_axes(
     projection: str = "MOL",
-    fov: Quantity | Tuple[Quantity, Quantity] = None,
+    fov: Quantity | tuple[Quantity, Quantity] = None,
     center: SkyCoord | None = None,
     wcs: astropy.wcs.WCS = None,
     frame_class: Type[BaseFrame] | None = None,

--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Tuple
 
 import numpy as np
 import pandas as pd
@@ -161,7 +160,7 @@ def read_parquet_metadata(file_pointer: str | Path | UPath, **kwargs) -> pq.File
     return parquet_file
 
 
-def read_parquet_dataset(source: str | Path | UPath, **kwargs) -> Tuple[UPath, Dataset]:
+def read_parquet_dataset(source: str | Path | UPath, **kwargs) -> tuple[UPath, Dataset]:
     """Read parquet dataset from directory pointer or list of files.
 
     Note that pyarrow.dataset reads require that directory pointers don't contain a
@@ -198,7 +197,7 @@ def read_parquet_dataset(source: str | Path | UPath, **kwargs) -> Tuple[UPath, D
 
 
 def write_parquet_metadata(
-    schema: Any, file_pointer: str | Path | UPath, metadata_collector: list | None = None, **kwargs
+    schema, file_pointer: str | Path | UPath, metadata_collector: list | None = None, **kwargs
 ):
     """Write a metadata only parquet file from a schema
 

--- a/src/hats/io/file_io/file_pointer.py
+++ b/src/hats/io/file_io/file_pointer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
 
 from upath import UPath
 
@@ -56,7 +55,7 @@ def is_regular_file(pointer: str | Path | UPath) -> bool:
     return pointer.is_file()
 
 
-def find_files_matching_path(pointer: str | Path | UPath, *paths: str) -> List[UPath]:
+def find_files_matching_path(pointer: str | Path | UPath, *paths: str) -> list[UPath]:
     """Find files or directories matching the provided path parts.
 
     Args:
@@ -96,7 +95,7 @@ def directory_has_contents(pointer: str | Path | UPath) -> bool:
     return len(find_files_matching_path(pointer, "*")) > 0
 
 
-def get_directory_contents(pointer: str | Path | UPath) -> List[UPath]:
+def get_directory_contents(pointer: str | Path | UPath) -> list[UPath]:
     """Finds all files and directories in the specified directory.
 
     NB: This is not recursive, and will return only the first level of directory contents.

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -153,7 +152,7 @@ def write_parquet_metadata(
     return total_rows
 
 
-def write_parquet_metadata_for_batches(batches: List[List[pa.RecordBatch]], output_path: str = None):
+def write_parquet_metadata_for_batches(batches: list[list[pa.RecordBatch]], output_path: str = None):
     """Write parquet metadata files for some pyarrow table batches.
     This writes the batches to a temporary parquet dataset using local storage, and
     generates the metadata for the partitioned catalog parquet files.
@@ -196,8 +195,8 @@ def read_row_group_fragments(metadata_file: str):
 def aggregate_column_statistics(
     metadata_file: str | Path | UPath,
     exclude_hats_columns: bool = True,
-    exclude_columns: List[str] = None,
-    include_columns: List[str] = None,
+    exclude_columns: list[str] = None,
+    include_columns: list[str] = None,
 ):
     """Read footer statistics in parquet metadata, and report on global min/max values.
 

--- a/src/hats/io/paths.py
+++ b/src/hats/io/paths.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Dict, List
 from urllib.parse import urlencode
 
 from fsspec.implementations.http import HTTPFileSystem
@@ -92,9 +91,9 @@ def get_healpix_from_path(path: str) -> HealpixPixel:
 
 def pixel_catalog_files(
     catalog_base_dir: str | Path | UPath | None,
-    pixels: List[HealpixPixel],
-    query_params: Dict | None = None,
-) -> List[UPath]:
+    pixels: list[HealpixPixel],
+    query_params: dict | None = None,
+) -> list[UPath]:
     """Create a list of path *pointers* for pixel catalog files. This will not create the directory
     or files.
 
@@ -137,7 +136,7 @@ def pixel_catalog_files(
     ]
 
 
-def dict_to_query_urlparams(query_params: Dict | None = None) -> str:
+def dict_to_query_urlparams(query_params: dict | None = None) -> str:
     """Converts a dictionary to a url query parameter string
 
     Args:
@@ -166,7 +165,7 @@ def dict_to_query_urlparams(query_params: Dict | None = None) -> str:
 
 
 def pixel_catalog_file(
-    catalog_base_dir: str | Path | UPath | None, pixel: HealpixPixel, query_params: Dict | None = None
+    catalog_base_dir: str | Path | UPath | None, pixel: HealpixPixel, query_params: dict | None = None
 ) -> UPath:
     """Create path *pointer* for a pixel catalog file. This will not create the directory
     or file.

--- a/src/hats/pixel_math/__init__.py
+++ b/src/hats/pixel_math/__init__.py
@@ -1,7 +1,7 @@
 """Utilities for performing fun math on healpix pixels"""
 
 from .healpix_pixel import HealpixPixel
-from .healpix_pixel_convertor import HealpixInputTypes, get_healpix_pixel
+from .healpix_pixel_convertor import get_healpix_pixel
 from .partition_stats import empty_histogram, generate_alignment, generate_histogram
 from .pixel_margins import get_margin
 from .spatial_index import compute_spatial_index, spatial_index_to_healpix

--- a/src/hats/pixel_math/box_filter.py
+++ b/src/hats/pixel_math/box_filter.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Tuple
 
 import numpy as np
 from astropy.coordinates import SkyCoord
 from mocpy import MOC
 
 
-def generate_box_moc(ra: Tuple[float, float], dec: Tuple[float, float], order: int) -> MOC:
+def generate_box_moc(ra: tuple[float, float], dec: tuple[float, float], order: int) -> MOC:
     """Generates a MOC object that covers the specified box. A box is delimited
     by right ascension and declination ranges. The right ascension edges follow
     great arc circles and the declination edges follow small arc circles.

--- a/src/hats/pixel_math/filter.py
+++ b/src/hats/pixel_math/filter.py
@@ -1,11 +1,9 @@
-from typing import List
-
 from hats.pixel_math import HealpixPixel
 from hats.pixel_tree import PixelAlignment, PixelAlignmentType, align_trees
 from hats.pixel_tree.pixel_tree import PixelTree
 
 
-def get_filtered_pixel_list(pixel_tree: PixelTree, search_tree: PixelTree) -> List[HealpixPixel]:
+def get_filtered_pixel_list(pixel_tree: PixelTree, search_tree: PixelTree) -> list[HealpixPixel]:
     """Aligns the catalog pixel tree with another pixel tree of interest, and
     extracts the HEALPix pixels that overlap. This method is useful to obtain
     the pixels intersecting a pre-defined search space.

--- a/src/hats/pixel_math/healpix_pixel.py
+++ b/src/hats/pixel_math/healpix_pixel.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
 
 import numpy as np
 
@@ -60,7 +59,7 @@ class HealpixPixel:
         new_order = self.order - delta_order
         return HealpixPixel(new_order, new_pixel)
 
-    def convert_to_higher_order(self, delta_order: int) -> List[HealpixPixel]:
+    def convert_to_higher_order(self, delta_order: int) -> list[HealpixPixel]:
         """Returns a list of HEALPix pixels making up the current pixel at a higher order
 
         Args:

--- a/src/hats/pixel_math/healpix_pixel_convertor.py
+++ b/src/hats/pixel_math/healpix_pixel_convertor.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-from typing import Tuple, Union
-
 from hats.pixel_math.healpix_pixel import HealpixPixel
 
-HealpixInputTypes = Union[HealpixPixel, Tuple[int, int]]
 
-
-def get_healpix_pixel(pixel: HealpixInputTypes) -> HealpixPixel:
+def get_healpix_pixel(pixel: HealpixPixel | tuple[int, int]) -> HealpixPixel:
     """Function to convert argument of either HealpixPixel or a tuple of (order, pixel) to a
     HealpixPixel
 
@@ -24,7 +20,7 @@ def get_healpix_pixel(pixel: HealpixInputTypes) -> HealpixPixel:
     raise TypeError("pixel must either be of type `HealpixPixel` or tuple (order, pixel)")
 
 
-def get_healpix_tuple(pixel: HealpixInputTypes) -> Tuple[int, int]:
+def get_healpix_tuple(pixel: HealpixPixel | tuple[int, int]) -> tuple[int, int]:
     """Function to convert argument of either HealpixPixel or a tuple of (order, pixel) to a
     tuple of (order, pixel)
 

--- a/src/hats/pixel_math/healpix_pixel_function.py
+++ b/src/hats/pixel_math/healpix_pixel_function.py
@@ -1,11 +1,9 @@
-from typing import List
-
 import numpy as np
 
 from hats.pixel_math.healpix_pixel import HealpixPixel
 
 
-def get_pixel_argsort(pixels: List[HealpixPixel]):
+def get_pixel_argsort(pixels: list[HealpixPixel]):
     """Perform an indirect sort of a list of HealpixPixels.
 
     This will order the pixels according to a breadth-first traversal of the healpix
@@ -29,7 +27,7 @@ def get_pixel_argsort(pixels: List[HealpixPixel]):
     return np.argsort(constant_breadth_pixel, kind="stable")
 
 
-def sort_pixels(pixels: List[HealpixPixel]):
+def sort_pixels(pixels: list[HealpixPixel]):
     """Perform an sort of a list of HealpixPixels.
 
     This will order the pixels according to a breadth-first traversal of the healpix

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 import numpy as np
 
 import hats.pixel_math.healpix_shim as hp
@@ -10,7 +8,7 @@ SPATIAL_INDEX_COLUMN = "_healpix_29"
 SPATIAL_INDEX_ORDER = 29
 
 
-def compute_spatial_index(ra_values: List[float], dec_values: List[float]) -> np.ndarray:
+def compute_spatial_index(ra_values: list[float], dec_values: list[float]) -> np.ndarray:
     """Compute the healpix index field.
 
     Args:
@@ -29,7 +27,7 @@ def compute_spatial_index(ra_values: List[float], dec_values: List[float]) -> np
     return mapped_pixels
 
 
-def spatial_index_to_healpix(ids: List[int], target_order: int = SPATIAL_INDEX_ORDER) -> np.ndarray:
+def spatial_index_to_healpix(ids: list[int], target_order: int = SPATIAL_INDEX_ORDER) -> np.ndarray:
     """Convert _healpix_29 values to the healpix pixel at the specified order
 
     Args:
@@ -43,7 +41,7 @@ def spatial_index_to_healpix(ids: List[int], target_order: int = SPATIAL_INDEX_O
     return np.array(ids) >> (2 * delta_order)
 
 
-def healpix_to_spatial_index(order: int | List[int], pixel: int | List[int]) -> np.int64 | np.ndarray:
+def healpix_to_spatial_index(order: int | list[int], pixel: int | list[int]) -> np.int64 | np.ndarray:
     """Convert a healpix pixel to the healpix index
 
     This maps the healpix pixel to the lowest pixel number within that pixel at order 29.

--- a/src/hats/pixel_math/validators.py
+++ b/src/hats/pixel_math/validators.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List, Tuple
 
 import numpy as np
 
@@ -34,7 +33,7 @@ def validate_radius(radius_arcsec: float):
         raise ValueError(ValidatorsErrors.INVALID_RADIUS.value)
 
 
-def validate_declination_values(dec: float | List[float]):
+def validate_declination_values(dec: float | list[float]):
     """Validates that declination values are in the [-90,90] degree range
 
     Args:
@@ -97,7 +96,7 @@ def check_polygon_is_valid(vertices: np.ndarray):
         raise ValueError(ValidatorsErrors.INVALID_CONCAVE_SHAPE.value)
 
 
-def validate_box(ra: Tuple[float, float], dec: Tuple[float, float]):
+def validate_box(ra: tuple[float, float], dec: tuple[float, float]):
     """Checks if ra and dec values are valid for the box search.
 
     - Both ranges for ra or dec must have been provided.

--- a/src/hats/pixel_tree/negative_tree.py
+++ b/src/hats/pixel_tree/negative_tree.py
@@ -1,11 +1,9 @@
-from typing import List
-
 from hats.pixel_math import HealpixPixel
 from hats.pixel_tree import PixelAlignmentType, align_trees
 from hats.pixel_tree.pixel_tree import PixelTree
 
 
-def compute_negative_tree_pixels(tree: PixelTree) -> List[HealpixPixel]:
+def compute_negative_tree_pixels(tree: PixelTree) -> list[HealpixPixel]:
     """Computes a 'negative pixel tree' consisting of the pixels needed to cover the full sky not in the tree
 
     Args:

--- a/src/hats/pixel_tree/pixel_alignment.py
+++ b/src/hats/pixel_tree/pixel_alignment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Dict, List
+from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -213,7 +213,7 @@ def _add_pixels_until(
     add_to: int,
     matching_pix: np.ndarray,
     is_left_pixel: bool,
-    mapping: List[np.ndarray],
+    mapping: list[np.ndarray],
 ):
     """Adds pixels of the greatest possible order to fill output from `add-from` to `add_to`
 
@@ -256,7 +256,7 @@ def _add_remaining_pixels(
     pixel_list: np.ndarray,
     index: int,
     is_left_pixel: bool,
-    mapping: List[np.ndarray],
+    mapping: list[np.ndarray],
 ):
     """Adds pixels to output and mapping from a given index in a list of pixel intervals
 
@@ -292,7 +292,7 @@ def perform_align_trees(
     right: np.ndarray,
     include_all_left: bool,
     include_all_right: bool,
-) -> List[np.ndarray]:
+) -> list[np.ndarray]:
     """Performs an alignment on arrays of pixel intervals
 
     Pixel interval lists must be of to the same order
@@ -428,7 +428,7 @@ def align_with_mocs(
     """
     left_moc = left_moc if left_moc is not None else left_tree.to_moc()
     right_moc = right_moc if right_moc is not None else right_tree.to_moc()
-    moc_intersection_methods: Dict[PixelAlignmentType, Callable[[MOC, MOC], MOC]] = {
+    moc_intersection_methods: dict[PixelAlignmentType, Callable[[MOC, MOC], MOC]] = {
         PixelAlignmentType.INNER: lambda l, r: l.intersection(r),
         PixelAlignmentType.LEFT: lambda l, r: l,
         PixelAlignmentType.RIGHT: lambda l, r: r,

--- a/src/hats/pixel_tree/pixel_tree.py
+++ b/src/hats/pixel_tree/pixel_tree.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import List
 
 import numpy as np
 from mocpy import MOC
@@ -80,7 +79,7 @@ class PixelTree:
         """
         return np.max(self.pixels.T[0])
 
-    def get_healpix_pixels(self) -> List[HealpixPixel]:
+    def get_healpix_pixels(self) -> list[HealpixPixel]:
         """Creates a list of HealpixPixels in the tree
 
         Returns (List[HealpixPixel]):

--- a/src/hats/pixel_tree/pixel_tree.py
+++ b/src/hats/pixel_tree/pixel_tree.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 import numpy as np
 from mocpy import MOC
 
-from hats.pixel_math import HealpixInputTypes, HealpixPixel
+from hats.pixel_math import HealpixPixel
 from hats.pixel_math.healpix_pixel_convertor import get_healpix_tuple
 from hats.pixel_math.healpix_pixel_function import get_pixels_from_intervals
 
@@ -47,7 +47,7 @@ class PixelTree:
         """
         return len(self.tree)
 
-    def contains(self, pixel: HealpixInputTypes) -> bool:
+    def contains(self, pixel: HealpixPixel | tuple[int, int]) -> bool:
         """Check if tree contains a node at a given order and pixel
 
         Args:
@@ -96,7 +96,9 @@ class PixelTree:
         return self.tree << (2 * (29 - self.tree_order))
 
     @classmethod
-    def from_healpix(cls, healpix_pixels: Sequence[HealpixInputTypes], tree_order=None) -> PixelTree:
+    def from_healpix(
+        cls, healpix_pixels: Sequence[HealpixPixel | tuple[int, int]], tree_order=None
+    ) -> PixelTree:
         """Build a tree from a list of constituent healpix pixels
 
         Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import os.path
 from pathlib import Path
-from typing import List
 
 import pandas as pd
 import pyarrow as pa
@@ -194,7 +193,7 @@ def catalog_path(test_data_dir) -> str:
 
 
 @pytest.fixture
-def margin_catalog_pixels() -> List[HealpixPixel]:
+def margin_catalog_pixels() -> list[HealpixPixel]:
     return [
         HealpixPixel(0, 4),
         HealpixPixel(1, 44),
@@ -210,7 +209,7 @@ def margin_catalog_path(test_data_dir) -> str:
 
 
 @pytest.fixture
-def catalog_pixels() -> List[HealpixPixel]:
+def catalog_pixels() -> list[HealpixPixel]:
     return [HealpixPixel(1, 0), HealpixPixel(1, 1), HealpixPixel(2, 8)]
 
 


### PR DESCRIPTION
Closes #406.

We still have statements like:

```
from typing import Iterable, Optional, Callable, Type, TYPE_CHECKING
from typing_extensions import Self
```