### PR TITLE
Ensure use of float64 when calling radec2pix

### DIFF
--- a/src/hats/pixel_math/healpix_shim.py
+++ b/src/hats/pixel_math/healpix_shim.py
@@ -62,8 +62,8 @@ def radec2pix(order: int, ra: float, dec: float) -> np.ndarray[np.int64]:
     if not is_order_valid(order):
         raise ValueError("Invalid value for order")
 
-    ra = Longitude(ra, unit="deg")
-    dec = Latitude(dec, unit="deg")
+    ra = Longitude(np.asarray(ra, dtype=np.float64), unit="deg")
+    dec = Latitude(np.asarray(dec, dtype=np.float64), unit="deg")
 
     return cdshealpix.lonlat_to_healpix(ra, dec, order).astype(np.int64)
 

--- a/tests/hats/pixel_math/test_healpix_shim.py
+++ b/tests/hats/pixel_math/test_healpix_shim.py
@@ -166,6 +166,22 @@ def test_radec2pix_lonlat():
         assert np.all(pixels == expected_pixels)
 
 
+def test_radec2pix_lonlat_float32():
+    orders = [0, 1, 5, 10, 20, 29]
+    ras = np.arange(-180.0, 180.0, 10.0)
+    ras_f = ras.astype(np.float32)
+    decs = np.arange(-90.0, 90.0, 180 // len(ras))
+    decs_f = decs.astype(np.float32)
+    for order in orders:
+        expected_pixels = cdshealpix.lonlat_to_healpix(
+            Longitude(ras, unit="deg"), Latitude(decs, unit="deg"), order
+        )
+        # Verify that healpixshim can work with float32 versions
+        # Fixes https://github.com/astronomy-commons/hats-import/issues/458
+        pixels = hps.radec2pix(order, ras_f, decs_f)
+        assert np.all(pixels == expected_pixels)
+
+
 def test_radec2pix_invalid():
     orders = [0, 1, 5, 10, 20, 29]
     invalid_orders = [-1000, -1, 30, 40]


### PR DESCRIPTION
## Change Description

In the function `healpix_shim.py.radec2pix`, convert `ra` and `dec` to 64-bit floating point before attempting to call `cdshealpix.lonlat_to_healpix`, which raises a `TypeError` if it receives 32-bit floating point.

Closes https://github.com/astronomy-commons/hats-import/issues/458 .

Have verified this fix both with an updated unit test, and also by exercising the code in a separate build of a margin cache, which produced another instance of the above issue.  This time, using a local checkout of this fix, the mapping phase continued past 5% without any instance of the error (which arose much earlier than the 5% mark before).

- [X] My PR includes a link to the issue that I am addressing


## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [X] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
