### PR TITLE
Change non-anchoring links to "anonymous" links.

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -4,7 +4,8 @@ Getting Started with HATS
 Installation
 ------------
 
-The latest release version of HATS is available to install with `pip <https://pypi.org/project/hats/>`_ (with conda coming soon).
+The latest release version of HATS is available to install with 
+`pip <https://pypi.org/project/hats/>`__ (with conda coming soon).
 
 .. code-block:: bash
 
@@ -35,14 +36,14 @@ The latest release version of HATS is available to install with `pip <https://py
 
     We recommend Python versions **>=3.10, <=3.12**.
 
-HATS can also be installed from source on `GitHub <https://github.com/astronomy-commons/hats>`_.
+HATS can also be installed from source on `GitHub <https://github.com/astronomy-commons/hats>`__.
 
 
 LSDB
 ----
 
 For the most part, we recommend accessing and processing HATS data using the `LSDB package
-<https://github.com/astronomy-commons/lsdb>`_ framework. LSDB provides a variety of utility
+<https://github.com/astronomy-commons/lsdb>`__ framework. LSDB provides a variety of utility
 functions as well as a lazy, distributed execution framework using Dask.
 
-For detail on LSDB, see the `readthedocs site <https://docs.lsdb.io/en/stable/>`_.
+For detail on LSDB, see the `readthedocs site <https://docs.lsdb.io/en/stable/>`__.

--- a/docs/guide/contributing.rst
+++ b/docs/guide/contributing.rst
@@ -50,11 +50,11 @@ Notes:
 2) ``pre-commit install`` will initialize pre-commit for this local repository, so
    that a set of tests will be run prior to completing a local commit. For more
    information, see the Python Project Template documentation on
-   `pre-commit <https://lincc-ppt.readthedocs.io/en/stable/practices/precommit.html>`_.
+   `pre-commit <https://lincc-ppt.readthedocs.io/en/stable/practices/precommit.html>`__.
 3) Install ``pandoc`` allows you to verify that automatic rendering of Jupyter notebooks
    into documentation for ReadTheDocs works as expected. For more information, see
    the Python Project Template documentation on
-   `Sphinx and Python Notebooks <https://lincc-ppt.readthedocs.io/en/stable/practices/sphinx.html#python-notebooks>`_.
+   `Sphinx and Python Notebooks <https://lincc-ppt.readthedocs.io/en/stable/practices/sphinx.html#python-notebooks>`__.
 
 .. tip::
     Installing on Mac
@@ -100,6 +100,6 @@ Optional - Release a new version
 -------------------------------------------------------------------------------
 
 Once your PR is merged you can create a new release to make your changes available. 
-GitHub's `instructions <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`_ 
+GitHub's `instructions <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`__ 
 for doing so are here. 
 Use your best judgement when incrementing the version. i.e. is this a major, minor, or patch fix.

--- a/docs/guide/directory_scheme.rst
+++ b/docs/guide/directory_scheme.rst
@@ -4,7 +4,7 @@ HATS Directory Scheme
 Partitioning Scheme
 -------------------------------------------------------------------------------
 
-We use healpix (`Hierarchical Equal Area isoLatitude Pixelization <https://healpix.jpl.nasa.gov/>`_)
+We use healpix (`Hierarchical Equal Area isoLatitude Pixelization <https://healpix.jpl.nasa.gov/>`__)
 for the spherical pixelation, and adaptively size the partitions based on the number of objects.
 
 In areas of the sky with more objects, we use smaller pixels, so that all the 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ HATS is a directory structure and metadata for spatially arranging large catalog
 This was originally motivated by a desire to perform spatial cross-matching between surveys 
 at large scale, but is applicable to a range of spatial analysis and algorithms.
 
-We use healpix (`Hierarchical Equal Area isoLatitude Pixelization <https://healpix.jpl.nasa.gov/_)
+We use healpix (`Hierarchical Equal Area isoLatitude Pixelization <https://healpix.jpl.nasa.gov/>`__)
 for the spherical pixelation, and adaptively size the partitions based on the number of objects.
 Each partition will have roughly the same number of objects, instead of dividing into equal area. 
 Because each partition is roughly the same size on disk, we can expect reasonable performance of 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ HATS is a directory structure and metadata for spatially arranging large catalog
 This was originally motivated by a desire to perform spatial cross-matching between surveys 
 at large scale, but is applicable to a range of spatial analysis and algorithms.
 
-We use healpix (`Hierarchical Equal Area isoLatitude Pixelization <https://healpix.jpl.nasa.gov/>`_)
+We use healpix (`Hierarchical Equal Area isoLatitude Pixelization <https://healpix.jpl.nasa.gov/_)
 for the spherical pixelation, and adaptively size the partitions based on the number of objects.
 Each partition will have roughly the same number of objects, instead of dividing into equal area. 
 Because each partition is roughly the same size on disk, we can expect reasonable performance of 
@@ -18,9 +18,9 @@ The ``hats`` python package provides basic access to a catalog's metadata, and s
 for interacting with the healpix space. This allows for multiple libraries to implement parallel 
 operations on top of these utilities. Some known extensions:
 
-* `LSDB <https://lsdb.readthedocs.io/>`_ - Large Survey Database - A framework for scalable 
+* `LSDB <https://lsdb.readthedocs.io/>`__ - Large Survey Database - A framework for scalable 
   spatial analysis using ``dask`` for job scheduling and execution.
-* `hats-import <https://hats-import.readthedocs.io/>`_ - map reduce pipelines for converting
+* `hats-import <https://hats-import.readthedocs.io/>`__ - map reduce pipelines for converting
   large or custom catalogs into HATS format.
 
 .. toctree::
@@ -42,7 +42,7 @@ Getting Started
 -------------------------------------------------------------------------------
 
 For the most part, we recommend accessing and processing HATS data using the `LSDB package
-<https://github.com/astronomy-commons/lsdb>`_ framework. LSDB provides a variety of utility
+<https://github.com/astronomy-commons/lsdb>`__ framework. LSDB provides a variety of utility
 functions as well as a lazy, distributed execution framework using Dask. However if you are are
 interested in using just the HATS package, you can find installation instructions at the 
 :doc:`getting started page</getting_started>`.


### PR DESCRIPTION
Adding a dunder to the end of the links makes them "anonymous" references, and then we're allowed to have more than one link with the same custom display text.