### PR TITLE
Don't pass additional kwargs to file open.

### DIFF
--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -118,7 +118,7 @@ def load_csv_to_pandas_generator(
         pandas dataframe loaded from CSV
     """
     file_pointer = get_upath(file_pointer)
-    with file_pointer.open(mode="rb", compression=compression, **kwargs) as csv_file:
+    with file_pointer.open(mode="rb", compression=compression) as csv_file:
         with pd.read_csv(csv_file, chunksize=chunksize, **kwargs) as reader:
             yield from reader
 


### PR DESCRIPTION
Ran into a problem with requests to HTTP and requiring a csv header row, where `{header:infer}` is a valid answer for pandas csv reader, but really confuses HTTP.