### PR TITLE
Enable anonymous S3 access by default

### DIFF
--- a/src/hats/io/file_io/__init__.py
+++ b/src/hats/io/file_io/__init__.py
@@ -22,5 +22,6 @@ from .file_pointer import (
     find_files_matching_path,
     get_directory_contents,
     get_upath,
+    get_upath_for_protocol,
     is_regular_file,
 )

--- a/src/hats/io/file_io/file_pointer.py
+++ b/src/hats/io/file_io/file_pointer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import botocore.exceptions
 from upath import UPath
 
 
@@ -22,9 +21,7 @@ def get_upath_for_protocol(path: str | Path) -> UPath:
     an anonymous access, i.e., that the bucket is public.
     """
     upath = UPath(path)
-    try:
-        upath.exists()
-    except botocore.exceptions.NoCredentialsError:
+    if upath.protocol == "s3":
         upath = UPath(path, anon=True)
     return upath
 

--- a/src/hats/io/file_io/file_pointer.py
+++ b/src/hats/io/file_io/file_pointer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from upath import UPath
 
 
-def get_upath(path: str | Path | UPath) -> UPath | None:
+def get_upath(path: str | Path | UPath) -> UPath:
     """Returns a file pointer from a path string"""
     if not path:
         return None

--- a/tests/hats/catalog/loaders/test_read_hats.py
+++ b/tests/hats/catalog/loaders/test_read_hats.py
@@ -22,6 +22,13 @@ def test_read_hats_branches(
 
 def test_read_hats_initializes_upath_once(small_sky_dir, mocker):
     mock_method = "hats.io.file_io.file_pointer.get_upath_for_protocol"
+    # Setting the side effect allows us to run the mocked function's code
     mocked_upath_call = mocker.patch(mock_method, side_effect=get_upath_for_protocol)
     read_hats(small_sky_dir)
+    # The construction of the UPath is called once, at the start of `read_hats`
     mocked_upath_call.assert_called_once_with(small_sky_dir)
+
+
+def test_read_hats_with_s3_anonymous_access():
+    upath = get_upath_for_protocol("s3://bucket/catalog")
+    assert upath.storage_options.get("anon")

--- a/tests/hats/catalog/loaders/test_read_hats.py
+++ b/tests/hats/catalog/loaders/test_read_hats.py
@@ -1,3 +1,4 @@
+from hats.io.file_io import get_upath_for_protocol
 from hats.loaders import read_hats
 
 
@@ -17,3 +18,10 @@ def test_read_hats_branches(
     read_hats(margin_catalog_path)
     read_hats(small_sky_source_dir)
     read_hats(test_data_dir / "square_map")
+
+
+def test_read_hats_initializes_upath_once(small_sky_dir, mocker):
+    mock_method = "hats.io.file_io.file_pointer.get_upath_for_protocol"
+    mocked_upath_call = mocker.patch(mock_method, side_effect=get_upath_for_protocol)
+    read_hats(small_sky_dir)
+    mocked_upath_call.assert_called_once_with(small_sky_dir)


### PR DESCRIPTION
Support anonymous S3 connections without requiring the user to provide a `UPath(..., anon=True)`. This change includes a test for `read_hats` which verifies that we only initialize the `UPath` once. Closes #462. 

- [X] My PR includes a link to the issue that I am addressing