### PR TITLE
Filtered catalog should retain path. Add friendlier check for in-memo…

### DIFF
--- a/src/hats/catalog/dataset/dataset.py
+++ b/src/hats/catalog/dataset/dataset.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
+import pandas as pd
 import pyarrow as pa
 from upath import UPath
 
@@ -52,6 +54,9 @@ class Dataset:
             include_columns (List[str]): if specified, only return statistics for the column
                 names provided. Defaults to None, and returns all non-hats columns.
         """
+        if not self.on_disk:
+            warnings.warn("Calling aggregate_column_statistics on an in-memory catalog. No results.")
+            return pd.DataFrame()
         return aggregate_column_statistics(
             self.catalog_base_dir / "dataset" / "_metadata",
             exclude_hats_columns=exclude_hats_columns,

--- a/src/hats/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hats/catalog/healpix_dataset/healpix_dataset.py
@@ -200,7 +200,13 @@ class HealpixDataset(Dataset):
         filtered_tree = filter_by_moc(self.pixel_tree, moc)
         filtered_moc = self.moc.intersection(moc) if self.moc is not None else None
         filtered_catalog_info = self.catalog_info.copy_and_update(total_rows=0)
-        return self.__class__(filtered_catalog_info, filtered_tree, moc=filtered_moc, schema=self.schema)
+        return self.__class__(
+            filtered_catalog_info,
+            pixels=filtered_tree,
+            catalog_path=self.catalog_path,
+            moc=filtered_moc,
+            schema=self.schema,
+        )
 
     def align(
         self, other_cat: Self, alignment_type: PixelAlignmentType = PixelAlignmentType.INNER

--- a/tests/hats/catalog/test_catalog.py
+++ b/tests/hats/catalog/test_catalog.py
@@ -105,6 +105,13 @@ def test_aggregate_column_statistics(small_sky_order1_dir):
     assert len(result_frame) == 2
 
 
+def test_aggregate_column_statistics_inmemory(catalog_info, catalog_pixels):
+    catalog = Catalog(catalog_info, catalog_pixels)
+    with pytest.warns(UserWarning, match="in-memory"):
+        result_frame = catalog.aggregate_column_statistics(include_columns=["ra", "dec"])
+    assert len(result_frame) == 0
+
+
 def test_load_catalog_small_sky_order1_moc(small_sky_order1_dir):
     """Instantiate a catalog with 4 pixels"""
     cat = read_hats(small_sky_order1_dir)
@@ -309,6 +316,7 @@ def test_box_filter(small_sky_order1_catalog):
     assert (1, 47) in filtered_catalog.pixel_tree
     assert len(filtered_catalog.pixel_tree.pixels[1]) == 2
     assert filtered_catalog.catalog_info.total_rows == 0
+    assert filtered_catalog.catalog_path is not None
 
     # Check that the previous filter is the same as intersecting the ra and dec filters
     assert filtered_catalog.moc is not None


### PR DESCRIPTION
The following scenario occured:

```
import lsdb
catalog = lsdb.read_hats(...)
catalog = catalog.cone_search(...)
catalog.aggregate_column_statistics()
```

This resulted in an error in the `aggregate_column_statistics` because the path became None during the geometric filter application.