### PR TITLE
Move collection of hive column names to shared library.

### DIFF
--- a/src/hats/io/paths.py
+++ b/src/hats/io/paths.py
@@ -20,6 +20,15 @@ MARGIN_ORDER = "margin_Norder"
 MARGIN_DIR = "margin_Dir"
 MARGIN_PIXEL = "margin_Npix"
 
+HIVE_COLUMNS = [
+    PARTITION_ORDER,
+    PARTITION_DIR,
+    PARTITION_PIXEL,
+    MARGIN_ORDER,
+    MARGIN_DIR,
+    MARGIN_PIXEL,
+]
+
 DATASET_DIR = "dataset"
 PARTITION_INFO_FILENAME = "partition_info.csv"
 PARTITION_JOIN_INFO_FILENAME = "partition_join_info.csv"


### PR DESCRIPTION
This is used in several places in LSDB. Helpful to have it closer to the definition of the constants.

See https://github.com/astronomy-commons/hats/issues/367