### PR TITLE
Granular, per-pixel statistics method.

### DIFF
--- a/src/.pylintrc
+++ b/src/.pylintrc
@@ -496,7 +496,7 @@ score=yes
 ignore-comments=yes
 
 # Docstrings are removed from the similarity computation
-ignore-docstrings=no
+ignore-docstrings=yes
 
 # Imports are removed from the similarity computation
 ignore-imports=yes

--- a/src/hats/catalog/dataset/dataset.py
+++ b/src/hats/catalog/dataset/dataset.py
@@ -84,7 +84,8 @@ class Dataset:
             include_stats (List[str]): if specified, only return the kinds of values from list
                 (min_value, max_value, null_count, row_count). Defaults to None, and returns all values.
             multiindex (bool): should the returned frame be created with a multi-index, first on
-                pixel, then on column name?
+                pixel, then on column name? Default is False, and instead indexes on pixel, with
+            separate columns per-data-column and stat value combination.
         """
         if not self.on_disk:
             warnings.warn("Calling per_pixel_statistics on an in-memory catalog. No results.")

--- a/src/hats/catalog/dataset/dataset.py
+++ b/src/hats/catalog/dataset/dataset.py
@@ -9,7 +9,7 @@ from upath import UPath
 
 from hats.catalog.dataset.table_properties import TableProperties
 from hats.io import file_io
-from hats.io.parquet_metadata import aggregate_column_statistics
+from hats.io.parquet_metadata import aggregate_column_statistics, per_pixel_statistics
 
 
 # pylint: disable=too-few-public-methods
@@ -62,4 +62,38 @@ class Dataset:
             exclude_hats_columns=exclude_hats_columns,
             exclude_columns=exclude_columns,
             include_columns=include_columns,
+        )
+
+    def per_pixel_statistics(
+        self,
+        exclude_hats_columns: bool = True,
+        exclude_columns: list[str] = None,
+        include_columns: list[str] = None,
+        include_stats: list[str] = None,
+        multiindex=False,
+    ):
+        """Read footer statistics in parquet metadata, and report on statistics about
+        each pixel partition.
+
+        Args:
+            exclude_hats_columns (bool): exclude HATS spatial and partitioning fields
+                from the statistics. Defaults to True.
+            exclude_columns (List[str]): additional columns to exclude from the statistics.
+            include_columns (List[str]): if specified, only return statistics for the column
+                names provided. Defaults to None, and returns all non-hats columns.
+            include_stats (List[str]): if specified, only return the kinds of values from list
+                (min_value, max_value, null_count, row_count). Defaults to None, and returns all values.
+            multiindex (bool): should the returned frame be created with a multi-index, first on
+                pixel, then on column name?
+        """
+        if not self.on_disk:
+            warnings.warn("Calling per_pixel_statistics on an in-memory catalog. No results.")
+            return pd.DataFrame()
+        return per_pixel_statistics(
+            self.catalog_base_dir / "dataset" / "_metadata",
+            exclude_hats_columns=exclude_hats_columns,
+            exclude_columns=exclude_columns,
+            include_columns=include_columns,
+            include_stats=include_stats,
+            multiindex=multiindex,
         )

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -127,6 +127,38 @@ def _nonemax(value1, value2):
     return max(value1, value2)
 
 
+def _pick_columns(
+    first_row_group,
+    exclude_hats_columns: bool = True,
+    exclude_columns: list[str] = None,
+    include_columns: list[str] = None,
+):
+    """Convenience method to find the desired columns and their indexes, given
+    some conventional user preferences."""
+
+    if include_columns is None:
+        include_columns = []
+
+    if exclude_columns is None:
+        exclude_columns = []
+    if exclude_hats_columns:
+        exclude_columns.extend(["Norder", "Dir", "Npix", "_healpix_29"])
+
+    column_names = [
+        first_row_group.column(col).path_in_schema for col in range(0, first_row_group.num_columns)
+    ]
+    column_names = [name.removesuffix(".list.element") for name in column_names]
+    good_column_indexes = [
+        index
+        for index, name in enumerate(column_names)
+        if (len(include_columns) == 0 or name in include_columns)
+        and not (len(exclude_columns) > 0 and name in exclude_columns)
+    ]
+    column_names = [column_names[i] for i in good_column_indexes]
+
+    return good_column_indexes, column_names
+
+
 def aggregate_column_statistics(
     metadata_file: str | Path | UPath,
     exclude_hats_columns: bool = True,
@@ -148,27 +180,15 @@ def aggregate_column_statistics(
     num_row_groups = total_metadata.num_row_groups
     first_row_group = total_metadata.row_group(0)
 
-    if include_columns is None:
-        include_columns = []
-
-    if exclude_columns is None:
-        exclude_columns = []
-    if exclude_hats_columns:
-        exclude_columns.extend(["Norder", "Dir", "Npix", "_healpix_29"])
-
-    column_names = [
-        first_row_group.column(col).path_in_schema for col in range(0, first_row_group.num_columns)
-    ]
-    column_names = [name.removesuffix(".list.element") for name in column_names]
-    good_column_indexes = [
-        index
-        for index, name in enumerate(column_names)
-        if (len(include_columns) == 0 or name in include_columns)
-        and not (len(exclude_columns) > 0 and name in exclude_columns)
-    ]
+    good_column_indexes, column_names = _pick_columns(
+        first_row_group=first_row_group,
+        exclude_hats_columns=exclude_hats_columns,
+        exclude_columns=exclude_columns,
+        include_columns=include_columns,
+    )
     if not good_column_indexes:
         return pd.DataFrame()
-    column_names = [column_names[i] for i in good_column_indexes]
+
     extrema = None
 
     for row_group_index in range(0, num_row_groups):
@@ -218,4 +238,89 @@ def aggregate_column_statistics(
             "row_count": stats_lists[3],
         }
     ).set_index("column_names")
+    return frame
+
+
+def per_pixel_statistics(
+    metadata_file: str | Path | UPath,
+    exclude_hats_columns: bool = True,
+    exclude_columns: list[str] = None,
+    include_columns: list[str] = None,
+    include_pixels: list[HealpixPixel] = None,
+    include_stats: list[str] = None,
+    multiindex=False,
+):
+    """Read footer statistics in parquet metadata, and report on min/max values
+    within individual pixel partitions.
+
+    Args:
+        metadata_file (str | Path | UPath): path to `_metadata` file
+        exclude_hats_columns (bool): exclude HATS spatial and partitioning fields
+            from the statistics. Defaults to True.
+        exclude_columns (List[str]): additional columns to exclude from the statistics.
+        include_columns (List[str]): if specified, only return statistics for the column
+            names provided. Defaults to None, and returns all non-hats columns.
+    """
+    total_metadata = file_io.read_parquet_metadata(metadata_file)
+    num_row_groups = total_metadata.num_row_groups
+    first_row_group = total_metadata.row_group(0)
+
+    good_column_indexes, column_names = _pick_columns(
+        first_row_group=first_row_group,
+        exclude_hats_columns=exclude_hats_columns,
+        exclude_columns=exclude_columns,
+        include_columns=include_columns,
+    )
+    if not good_column_indexes:
+        return pd.DataFrame()
+
+    all_stats = ["min_value", "max_value", "null_count", "row_count"]
+
+    if include_stats is None or len(include_stats) == 0:
+        include_stats = all_stats
+    else:
+        for stat in include_stats:
+            if stat not in all_stats:
+                raise ValueError(f"include_stats must be from list {all_stats} (found {stat})")
+
+    stat_mask = np.array([ind for ind, stat in enumerate(all_stats) if stat in include_stats])
+    pixels = []
+    leaf_stats = []
+
+    for row_group_index in range(0, num_row_groups):
+        row_group = total_metadata.row_group(row_group_index)
+        pixel = paths.get_healpix_from_path(row_group.column(0).file_path)
+        if include_pixels is not None and pixel not in include_pixels:
+            continue
+        row_stats = [
+            (
+                [None, None, 0, 0]
+                if row_group.column(col).statistics is None
+                else [
+                    row_group.column(col).statistics.min,
+                    row_group.column(col).statistics.max,
+                    row_group.column(col).statistics.null_count,
+                    row_group.column(col).num_values,
+                ]
+            )
+            for col in good_column_indexes
+        ]
+        row_stats = np.take(row_stats, stat_mask, axis=1)
+        pixels.append(pixel)
+        leaf_stats.append(row_stats)
+
+    stats_lists = np.array(leaf_stats)
+    original_shape = stats_lists.shape
+    if multiindex:
+        stats_lists = stats_lists.reshape((original_shape[0] * original_shape[1], original_shape[2]))
+        frame = pd.DataFrame(
+            stats_lists,
+            index=pd.MultiIndex.from_product([pixels, column_names], names=["pixel", "column"]),
+            columns=include_stats,
+        )
+    else:
+        stats_lists = stats_lists.reshape((original_shape[0], original_shape[1] * original_shape[2]))
+        mod_col_names = [[f"{col_name}: {stat}" for stat in include_stats] for col_name in column_names]
+        mod_col_names = np.array(mod_col_names).flatten()
+        frame = pd.DataFrame(stats_lists, index=pixels, columns=mod_col_names)
     return frame

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -175,6 +175,10 @@ def aggregate_column_statistics(
         exclude_columns (List[str]): additional columns to exclude from the statistics.
         include_columns (List[str]): if specified, only return statistics for the column
             names provided. Defaults to None, and returns all non-hats columns.
+        include_pixels (list[HealpixPixel]): if specified, only return statistics
+            for the pixels indicated. Defaults to none, and returns all pixels.
+    Returns:
+        dataframe with global summary statistics
     """
     total_metadata = file_io.read_parquet_metadata(metadata_file)
     num_row_groups = total_metadata.num_row_groups
@@ -246,12 +250,12 @@ def per_pixel_statistics(
     exclude_hats_columns: bool = True,
     exclude_columns: list[str] = None,
     include_columns: list[str] = None,
-    include_pixels: list[HealpixPixel] = None,
     include_stats: list[str] = None,
     multiindex=False,
+    include_pixels: list[HealpixPixel] = None,
 ):
-    """Read footer statistics in parquet metadata, and report on min/max values
-    within individual pixel partitions.
+    """Read footer statistics in parquet metadata, and report on statistics about
+    each pixel partition.
 
     Args:
         metadata_file (str | Path | UPath): path to `_metadata` file
@@ -260,6 +264,15 @@ def per_pixel_statistics(
         exclude_columns (List[str]): additional columns to exclude from the statistics.
         include_columns (List[str]): if specified, only return statistics for the column
             names provided. Defaults to None, and returns all non-hats columns.
+        include_pixels (list[HealpixPixel]): if specified, only return statistics
+            for the pixels indicated. Defaults to none, and returns all pixels.
+        include_stats (List[str]): if specified, only return the kinds of values from list
+            (min_value, max_value, null_count, row_count). Defaults to None, and returns all values.
+        multiindex (bool): should the returned frame be created with a multi-index, first on
+            pixel, then on column name? Default is False, and instead indexes on pixel, with
+            separate columns per-data-column and stat value combination.
+    Returns:
+        dataframe with granular per-pixel statistics
     """
     total_metadata = file_io.read_parquet_metadata(metadata_file)
     num_row_groups = total_metadata.num_row_groups
@@ -311,6 +324,7 @@ def per_pixel_statistics(
 
     stats_lists = np.array(leaf_stats)
     original_shape = stats_lists.shape
+
     if multiindex:
         stats_lists = stats_lists.reshape((original_shape[0] * original_shape[1], original_shape[2]))
         frame = pd.DataFrame(

--- a/tests/hats/io/test_parquet_metadata.py
+++ b/tests/hats/io/test_parquet_metadata.py
@@ -7,7 +7,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from hats.io import file_io, paths
-from hats.io.parquet_metadata import aggregate_column_statistics, write_parquet_metadata
+from hats.io.parquet_metadata import aggregate_column_statistics, per_pixel_statistics, write_parquet_metadata
 from hats.pixel_math.healpix_pixel import HealpixPixel
 
 
@@ -232,3 +232,54 @@ def test_aggregate_column_statistics_with_nulls(tmp_path):
 
     assert_column_stat_as_floats(result_frame, "data", min_value=-1, max_value=2, null_count=4, row_count=6)
     assert_column_stat_as_floats(result_frame, "Npix", min_value=1, max_value=6, null_count=4, row_count=6)
+
+
+def test_per_pixel_statistics(small_sky_order1_dir):
+    partition_info_file = paths.get_parquet_metadata_pointer(small_sky_order1_dir)
+
+    result_frame = per_pixel_statistics(partition_info_file)
+    # 20 = 5 columns * 4 stats per-column
+    assert result_frame.shape == (4, 20)
+
+    result_frame = per_pixel_statistics(partition_info_file, exclude_hats_columns=False)
+    # 36 = 9 columns * 4 stats per-column
+    assert result_frame.shape == (4, 36)
+
+    result_frame = per_pixel_statistics(partition_info_file, include_columns=["ra", "dec"])
+    # 8 = 2 columns * 4 stats per-column
+    assert result_frame.shape == (4, 8)
+
+    result_frame = per_pixel_statistics(partition_info_file, include_columns=["does", "not", "exist"])
+    assert len(result_frame) == 0
+
+
+def test_per_pixel_statistics_multiindex(small_sky_order1_dir):
+    partition_info_file = paths.get_parquet_metadata_pointer(small_sky_order1_dir)
+
+    result_frame = per_pixel_statistics(partition_info_file, multiindex=True)
+    # 20 = 5 columns * 4 pixels
+    assert result_frame.shape == (20, 4)
+
+    result_frame = per_pixel_statistics(partition_info_file, exclude_hats_columns=False, multiindex=True)
+    # 36 = 9 columns * 4 stats per-column
+    assert result_frame.shape == (36, 4)
+
+
+def test_per_pixel_statistics_include_stats(small_sky_order1_dir):
+    partition_info_file = paths.get_parquet_metadata_pointer(small_sky_order1_dir)
+
+    result_frame = per_pixel_statistics(partition_info_file, include_stats=["row_count"])
+    # 5 = 5 columns * 1 stat per column
+    assert result_frame.shape == (4, 5)
+
+    result_frame = per_pixel_statistics(
+        partition_info_file, include_stats=["row_count"], include_columns=["id"]
+    )
+    # 1 = 1 columns * 1 stat per column
+    assert result_frame.shape == (4, 1)
+
+    result_frame = per_pixel_statistics(
+        partition_info_file, include_stats=["row_count"], include_columns=["id"], multiindex=True
+    )
+    # 1 = 1 columns * 1 stat per column
+    assert result_frame.shape == (4, 1)


### PR DESCRIPTION
See https://github.com/astronomy-commons/lsdb/issues/550

Adds a method in HATS to get granular per-pixel statistics. This is really customizable, to reduce the size of the returned object in case there are many pixels or many columns (or both).

Extracts some shared logic with the similar `aggregate_column_statistics` method.