### PR TITLE
Add `extra_dict` method to `TableProperties`

### DIFF
--- a/src/hats/catalog/dataset/table_properties.py
+++ b/src/hats/catalog/dataset/table_properties.py
@@ -189,11 +189,17 @@ class TableProperties(BaseModel):
         TableProperties.model_validate(new_properties)
         return new_properties
 
-    def explicit_dict(self):
+    def explicit_dict(self, by_alias=False, exclude_none=True):
         """Create a dict, based on fields that have been explicitly set, and are not "extra" keys."""
-        explicit = self.model_dump(by_alias=False, exclude_none=True)
+        explicit = self.model_dump(by_alias=by_alias, exclude_none=exclude_none)
         extra_keys = self.__pydantic_extra__.keys()
         return {key: val for key, val in explicit.items() if key not in extra_keys}
+
+    def extra_dict(self, by_alias=False, exclude_none=True):
+        """Create a dict, based on fields that are "extra" keys."""
+        explicit = self.model_dump(by_alias=by_alias, exclude_none=exclude_none)
+        extra_keys = self.__pydantic_extra__.keys()
+        return {key: val for key, val in explicit.items() if key in extra_keys}
 
     def __str__(self):
         """Friendly string representation based on named fields."""

--- a/tests/hats/catalog/dataset/test_table_properties.py
+++ b/tests/hats/catalog/dataset/test_table_properties.py
@@ -136,3 +136,22 @@ def test_read_from_dir_branches(
     TableProperties.read_from_dir(small_sky_source_object_index_dir)
     TableProperties.read_from_dir(margin_catalog_path)
     TableProperties.read_from_dir(small_sky_source_dir)
+
+
+def test_extra_dict():
+    extra_properties = {
+        "hats_copyright": "LINCC Frameworks 2024",
+        "hats_estsize": 10000000,
+        "hats_max_rows": 1000000,
+    }
+    table_properties = TableProperties(
+        catalog_name="foo",
+        catalog_type="index",
+        total_rows=15,
+        extra_columns="a , b",
+        indexing_column="a",
+        primary_catalog="bar",
+        **extra_properties,
+    )
+
+    assert table_properties.extra_dict() == extra_properties


### PR DESCRIPTION
Adds an `extra_dict` method that gets the non explicit parameters on the class as a compliment to the existing `explicit_dict` method.