### PR TITLE
Update moc fov to determine order based on FOV size

### DIFF
--- a/src/hats/inspection/visualize_catalog.py
+++ b/src/hats/inspection/visualize_catalog.py
@@ -246,8 +246,16 @@ def get_fov_moc_from_wcs(wcs: WCS) -> MOC | None:
     if np.isnan(ra_deg).any() or np.isnan(dec_deg).any():
         return None
 
-    # Create a rough MOC (depth=3 is sufficient) from the viewport
-    moc_viewport = MOC.from_polygon_skycoord(viewport, max_depth=3)
+    max_distance = np.max([np.ptp(ra_deg), np.ptp(dec_deg)])
+
+    # max_depth for moc calculated from (very) approximate max distance between points in the viewport
+    # distance divided by 4 to make sure moc pixel size < viewport size
+    # min max depth of 3 to match original mocpy method
+    max_depth = hp.avgsize2order((max_distance / 4) * 60)
+
+    max_depth = np.max([max_depth, 3])
+
+    moc_viewport = MOC.from_polygon_skycoord(viewport, max_depth=max_depth)
     return moc_viewport
 
 

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -15,17 +15,17 @@ from mocpy.moc.plot import fill
 from mocpy.moc.plot.culling_backfacing_cells import from_moc
 from mocpy.moc.plot.utils import build_plotting_moc
 
+import hats.pixel_math.healpix_shim as hp
 from hats import read_hats
 from hats.inspection import plot_density, plot_pixels
 from hats.inspection.visualize_catalog import (
     compute_healpix_vertices,
     cull_from_pixel_map,
     cull_to_fov,
+    get_fov_moc_from_wcs,
     plot_healpix_map,
     plot_moc,
-    get_fov_moc_from_wcs,
 )
-import hats.pixel_math.healpix_shim as hp
 
 # pylint: disable=no-member
 

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -262,7 +262,7 @@ def test_fov_moc():
         projection=DEFAULT_PROJECTION,
     ).w
     fov_moc = get_fov_moc_from_wcs(wcs)
-    fov_hp_order = hp.avgsize2order((fov[0] / 4).value * 3600)
+    fov_hp_order = hp.avgsize2order((fov[0]).value * 3600)
     assert fov_moc.max_order >= fov_hp_order
     ras_in = np.linspace(center.ra - (fov[0] / 2), center.ra + (fov[0] / 2))
     decs_in = np.linspace(center.dec - (fov[1] / 2), center.dec + (fov[1] / 2))
@@ -285,7 +285,7 @@ def test_fov_moc_small():
         projection=DEFAULT_PROJECTION,
     ).w
     fov_moc = get_fov_moc_from_wcs(wcs)
-    fov_hp_order = hp.avgsize2order((fov[0] / 4).value)
+    fov_hp_order = hp.avgsize2order((fov[0]).value)
     assert fov_moc.max_order >= fov_hp_order
     ras_in = np.linspace(center.ra - (fov[0] / 2), center.ra + (fov[0] / 2))
     decs_in = np.linspace(center.dec - (fov[1] / 2), center.dec + (fov[1] / 2))


### PR DESCRIPTION
Changes the method to generate a moc that covers a WCSAxes FOV originally used from mocpy. It used to use a MOC order of 3, but when trying to perform filtering on a catalog based on the viewport of the plot, such as in the `plot_points` method, this wasn't fine enough for all use cases. Now computes the order based on the fov.

Fixes https://github.com/astronomy-commons/lsdb/issues/697