### PR TITLE
Add original schema property to dataset

### DIFF
--- a/src/hats/catalog/association_catalog/association_catalog.py
+++ b/src/hats/catalog/association_catalog/association_catalog.py
@@ -28,8 +28,11 @@ class AssociationCatalog(HealpixDataset):
         catalog_path=None,
         moc: MOC | None = None,
         schema: pa.Schema | None = None,
+        original_schema: pa.Schema | None = None,
     ) -> None:
-        super().__init__(catalog_info, pixels, catalog_path, moc=moc, schema=schema)
+        super().__init__(
+            catalog_info, pixels, catalog_path, moc=moc, schema=schema, original_schema=original_schema
+        )
         self.join_info = self._get_partition_join_info_from_pixels(join_pixels)
 
     def get_join_pixels(self) -> pd.DataFrame:

--- a/src/hats/catalog/dataset/dataset.py
+++ b/src/hats/catalog/dataset/dataset.py
@@ -22,6 +22,7 @@ class Dataset:
         catalog_info: TableProperties,
         catalog_path: str | Path | UPath | None = None,
         schema: pa.Schema | None = None,
+        original_schema: pa.Schema | None = None,
     ) -> None:
         """Initializes a Dataset
 
@@ -38,6 +39,7 @@ class Dataset:
         self.on_disk = catalog_path is not None
         self.catalog_base_dir = file_io.get_upath(self.catalog_path)
         self.schema = schema
+        self.original_schema = original_schema
 
     def aggregate_column_statistics(
         self,

--- a/src/hats/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hats/catalog/healpix_dataset/healpix_dataset.py
@@ -48,6 +48,7 @@ class HealpixDataset(Dataset):
         catalog_path: str | Path | UPath | None = None,
         moc: MOC | None = None,
         schema: pa.Schema | None = None,
+        original_schema: pa.Schema | None = None,
     ) -> None:
         """Initializes a Catalog
 
@@ -60,7 +61,9 @@ class HealpixDataset(Dataset):
             moc (mocpy.MOC): MOC object representing the coverage of the catalog
             schema (pa.Schema): The pyarrow schema for the catalog
         """
-        super().__init__(catalog_info, catalog_path=catalog_path, schema=schema)
+        super().__init__(
+            catalog_info, catalog_path=catalog_path, schema=schema, original_schema=original_schema
+        )
         self.partition_info = self._get_partition_info_from_pixels(pixels)
         self.pixel_tree = self._get_pixel_tree_from_pixels(pixels)
         self.moc = moc
@@ -208,6 +211,7 @@ class HealpixDataset(Dataset):
             catalog_path=self.catalog_path,
             moc=filtered_moc,
             schema=self.schema,
+            original_schema=self.original_schema,
         )
 
     def align(

--- a/src/hats/loaders/read_hats.py
+++ b/src/hats/loaders/read_hats.py
@@ -70,10 +70,12 @@ def _load_catalog(catalog_path: UPath) -> Dataset:
             raise NotImplementedError(f"Cannot load catalog of type {dataset_type}")
 
         loader = DATASET_TYPE_TO_CLASS[dataset_type]
+        schema = _read_schema_from_metadata(catalog_path)
         kwargs = {
             "catalog_path": catalog_path,
             "catalog_info": properties,
-            "schema": _read_schema_from_metadata(catalog_path),
+            "schema": schema,
+            "original_schema": schema,
         }
         if _is_healpix_dataset(dataset_type):
             kwargs["pixels"] = PartitionInfo.read_from_dir(catalog_path)

--- a/tests/hats/catalog/loaders/test_read_hats.py
+++ b/tests/hats/catalog/loaders/test_read_hats.py
@@ -2,6 +2,7 @@ import shutil
 
 import pytest
 
+import hats
 from hats.catalog.catalog_collection import CatalogCollection
 from hats.catalog.dataset.collection_properties import CollectionProperties
 from hats.io.file_io import get_upath_for_protocol
@@ -123,3 +124,8 @@ def test_read_hats_nonstandard_npix_suffix(
 ):
     read_hats(small_sky_npix_alt_suffix_dir)
     read_hats(small_sky_npix_as_dir_dir)
+
+
+def test_read_hats_original_schema(small_sky_order1_dir):
+    cat = hats.read_hats(small_sky_order1_dir)
+    assert cat.schema == cat.original_schema

--- a/tests/hats/catalog/test_catalog.py
+++ b/tests/hats/catalog/test_catalog.py
@@ -221,6 +221,7 @@ def test_cone_filter(small_sky_order1_catalog):
         max_depth=small_sky_order1_catalog.get_max_coverage_order(),
     )
     assert filtered_catalog.moc == cone_moc.intersection(small_sky_order1_catalog.moc)
+    assert filtered_catalog.original_schema is not None
 
 
 def test_cone_filter_big(small_sky_order1_catalog):
@@ -274,6 +275,7 @@ def test_polygonal_filter(small_sky_order1_catalog):
         max_depth=small_sky_order1_catalog.get_max_coverage_order(),
     )
     assert filtered_catalog.moc == polygon_moc.intersection(small_sky_order1_catalog.moc)
+    assert filtered_catalog.original_schema is not None
 
 
 def test_polygonal_filter_invalid_coordinate_shape(small_sky_order1_catalog):


### PR DESCRIPTION
Working towards https://github.com/astronomy-commons/lsdb/issues/654 adds an extra property on dataset that keeps track of the original schema of the catalog.