### PR TITLE
add int64 dtype conversion to pixel tree

### DIFF
--- a/src/hats/pixel_tree/pixel_tree.py
+++ b/src/hats/pixel_tree/pixel_tree.py
@@ -32,7 +32,7 @@ class PixelTree:
             order (int): HEALPix order of the pixel numbers in the intervals
         """
         self.tree_order = order
-        self.tree = tree
+        self.tree = tree.astype(np.int64)
 
         if not np.all((self.tree.T[0, 1:] - self.tree.T[1, :-1]) >= 0):
             raise ValueError("Invalid Catalog: Tree contains overlapping pixels")
@@ -113,7 +113,7 @@ class PixelTree:
             return PixelTree(np.empty((0, 2), dtype=np.int64), 0)
 
         pixel_tuples = [get_healpix_tuple(p) for p in healpix_pixels]
-        pixel_array = np.array(pixel_tuples).T
+        pixel_array = np.array(pixel_tuples, dtype=np.int64).T
         orders = pixel_array[0]
         pixels = pixel_array[1]
         max_order = np.max(orders) if tree_order is None else tree_order

--- a/tests/hats/pixel_tree/test_pixel_tree.py
+++ b/tests/hats/pixel_tree/test_pixel_tree.py
@@ -5,6 +5,20 @@ from hats.pixel_math.healpix_pixel import get_higher_order_pixels
 from hats.pixel_tree.pixel_tree import PixelTree
 
 
+def test_pixel_tree_from_healpix():
+    tree = PixelTree.from_healpix([(0, 0)])
+    assert tree.contains((0, 0))
+    assert len(tree.to_depth29_ranges()) == 1
+    assert tree.tree.dtype == np.int64
+
+
+def test_pixel_tree_wrong_input_type():
+    tree = PixelTree(np.array([[0, 1]], dtype=np.int32), order=0)
+    assert tree.contains((0, 0))
+    assert len(tree.to_depth29_ranges()) == 1
+    assert tree.tree.dtype == np.int64
+
+
 def test_pixel_tree_length():
     lengths = [1, 3, 6]
     orders = [1, 2, 7]


### PR DESCRIPTION
Fixes filtering bug that arises from pixel tree being created with wrong np dtype. Closes https://github.com/astronomy-commons/lsdb/issues/715