### PR TITLE
Handle list and dict input for properties creation.

### DIFF
--- a/src/hats/catalog/dataset/collection_properties.py
+++ b/src/hats/catalog/dataset/collection_properties.py
@@ -3,6 +3,7 @@ from functools import reduce
 from pathlib import Path
 from typing import Iterable, Optional
 
+import pandas as pd
 from jproperties import Properties
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
 from typing_extensions import Self
@@ -63,6 +64,10 @@ class CollectionProperties(BaseModel):
     @classmethod
     def space_delimited_list(cls, str_value: str) -> list[str]:
         """Convert a space-delimited list string into a python list of strings."""
+        if str_value is None:
+            return None
+        if pd.api.types.is_list_like(str_value):
+            return list(str_value)
         if not str_value or not isinstance(str_value, str):
             ## Convert empty strings and empty lists to None
             return None
@@ -73,6 +78,10 @@ class CollectionProperties(BaseModel):
     @classmethod
     def index_tuples(cls, str_value: str) -> dict[str, str]:
         """Convert a space-delimited list string into a python list of strings."""
+        if str_value is None:
+            return None
+        if pd.api.types.is_dict_like(str_value):
+            return dict(str_value)
         if not str_value or not isinstance(str_value, str):
             return None
         # Split on a few kinds of delimiters (just to be safe), and remove duplicates

--- a/tests/hats/catalog/dataset/test_collection_properties.py
+++ b/tests/hats/catalog/dataset/test_collection_properties.py
@@ -163,3 +163,36 @@ def test_read_collection_all_indexes_not_specified(small_sky_collection_dir, tmp
     table_properties.to_properties_file(tmp_path)
     with pytest.raises(ValueError, match="all_indexes needs to be set"):
         CollectionProperties.read_from_dir(tmp_path)
+
+
+def test_collection_parsing(small_sky_collection_dir):
+    ## Confirm we can pass in already dict- or list-like objects, and get the expected values.
+    properties_from_file = CollectionProperties.read_from_dir(small_sky_collection_dir)
+
+    expected_properties = CollectionProperties(
+        name="small_sky_01",
+        hats_primary_table_url="small_sky_order1",
+        all_margins=["small_sky_order1_margin"],
+        default_margin="small_sky_order1_margin",
+        all_indexes={"id": "small_sky_order1_id_index"},
+        default_index="id",
+        obs_regime="Optical",
+    )
+
+    assert properties_from_file == expected_properties
+
+    simple_properties = CollectionProperties(
+        name="small_sky_01",
+        hats_primary_table_url="small_sky_order1",
+    )
+
+    simple_properties_with_none = CollectionProperties(
+        name="small_sky_01",
+        hats_primary_table_url="small_sky_order1",
+        all_margins=None,
+        default_margin=None,
+        all_indexes=None,
+        default_index=None,
+    )
+
+    assert simple_properties == simple_properties_with_none


### PR DESCRIPTION
Related to #482 and https://github.com/astronomy-commons/hats-import/issues/510.

I'm creating the properties from constructed values, and wanted to pass in a list and dict for some values. This enables doing that, and avoids re-parsing when the input is already a list or dict.