### PR TITLE
Add github button to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,10 @@ autoapi_add_toc_tree_entry = False
 autoapi_member_order = "bysource"
 
 html_theme = "sphinx_book_theme"
+html_theme_options = {
+    "repository_url": "https://github.com/astronomy-commons/hats",
+    "use_repository_button": True,
+}
 
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]


### PR DESCRIPTION
Adds an octocat button which leads to the github repo:

<img width="251" alt="image" src="https://github.com/user-attachments/assets/081c5001-b888-49d2-9ab3-0e56f57b2138" />

It is a prototype for https://github.com/lincc-frameworks/python-project-template/issues/500