### PR TITLE
Generate data thumbnail

### DIFF
--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -65,15 +65,17 @@ def write_parquet_metadata(
     # Collect the healpix pixels so we can sort before writing.
     healpix_pixels = []
     total_rows = 0
+
     # Collect the first rows for the data thumbnail
     first_rows = []
-
-    # The pixel threshold is the maximum number of Parquet rows per pixel,
-    # used to prevent memory issues. It doesn't make sense for the thumbnail
-    # to have more rows than this. If it does, randomly sample those available.
-    row_limit = min(len(dataset.files), pixel_threshold)
-    # Create set for O(1) lookups in the loop that follows
-    pq_file_list = set(random.sample(dataset.files, row_limit))
+    pq_file_list = set()
+    if create_thumbnail:
+        # The pixel threshold is the maximum number of Parquet rows per pixel,
+        # used to prevent memory issues. It doesn't make sense for the thumbnail
+        # to have more rows than this. If it does, randomly sample those available.
+        row_limit = min(len(dataset.files), pixel_threshold)
+        # Create set for O(1) lookups in the loop that follows
+        pq_file_list = set(random.sample(dataset.files, row_limit))
 
     for single_file in dataset.files:
         relative_path = single_file[len(dataset_path) + 1 :]
@@ -85,8 +87,8 @@ def write_parquet_metadata(
 
         if order_by_healpix:
             healpix_pixel = paths.get_healpix_from_path(relative_path)
-
             healpix_pixels.append(healpix_pixel)
+
         metadata_collector.append(single_metadata)
         total_rows += single_metadata.num_rows
 

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -15,6 +15,7 @@ from hats.io import file_io, paths
 from hats.io.file_io.file_pointer import get_upath
 from hats.pixel_math.healpix_pixel import HealpixPixel
 from hats.pixel_math.healpix_pixel_function import get_pixel_argsort
+from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN
 
 
 def write_parquet_metadata(
@@ -102,7 +103,9 @@ def write_parquet_metadata(
     ## Write out the thumbnail file
     if create_thumbnail:
         data_thumbnail_pointer = paths.get_data_thumbnail_pointer(catalog_path)
-        data_thumbnail = pa.Table.from_batches(first_rows)
+        data_thumbnail = pa.Table.from_batches(first_rows, dataset.schema)
+        if SPATIAL_INDEX_COLUMN in data_thumbnail.column_names:
+            data_thumbnail = data_thumbnail.sort_by(SPATIAL_INDEX_COLUMN)
         with data_thumbnail_pointer.open("wb") as f_out:
             pq.write_table(data_thumbnail, f_out)
 

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -41,8 +41,8 @@ def write_parquet_metadata(
             defaults to `catalog_path` if unspecified
         create_thumbnail (bool): if True, create a data thumbnail parquet file for
             the dataset. Defaults to True.
-        thumbnail_threshold (int): the number of points per partition specified when
-            importing the catalog. Defaults to 1_000_000.
+        thumbnail_threshold (int): maximum number of rows in the data thumbnail,
+            which is otherwise one row/partition. Defaults to 1_000_000.
 
     Returns:
         sum of the number of rows in the dataset.

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -25,7 +25,7 @@ def write_parquet_metadata(
     order_by_healpix=True,
     output_path: str | Path | UPath | None = None,
     create_thumbnail: bool = True,
-    pixel_threshold: int = 1_000_000,
+    thumbnail_threshold: int = 1_000_000,
 ):
     """Generate parquet metadata, using the already-partitioned parquet files
     for this catalog.
@@ -41,7 +41,7 @@ def write_parquet_metadata(
             defaults to `catalog_path` if unspecified
         create_thumbnail (bool): if True, create a data thumbnail parquet file for
             the dataset. Defaults to True.
-        pixel_threshold (int): the number of points per partition specified when
+        thumbnail_threshold (int): the number of points per partition specified when
             importing the catalog. Defaults to 1_000_000.
 
     Returns:
@@ -70,10 +70,11 @@ def write_parquet_metadata(
     first_rows = []
     pq_file_list = set()
     if create_thumbnail:
-        # The pixel threshold is the maximum number of Parquet rows per pixel,
-        # used to prevent memory issues. It doesn't make sense for the thumbnail
-        # to have more rows than this. If it does, randomly sample those available.
-        row_limit = min(len(dataset.files), pixel_threshold)
+        # The thumbnail_threshold threshold is the maximum number of Parquet rows
+        # per pixel, used to prevent memory issues. It doesn't make sense for the
+        # thumbnail to have more rows than this. If it does, randomly sample those
+        # available.
+        row_limit = min(len(dataset.files), thumbnail_threshold)
         # Create set for O(1) lookups in the loop that follows
         pq_file_list = set(random.sample(dataset.files, row_limit))
 

--- a/src/hats/io/paths.py
+++ b/src/hats/io/paths.py
@@ -34,6 +34,7 @@ PARTITION_INFO_FILENAME = "partition_info.csv"
 PARTITION_JOIN_INFO_FILENAME = "partition_join_info.csv"
 PARQUET_METADATA_FILENAME = "_metadata"
 PARQUET_COMMON_METADATA_FILENAME = "_common_metadata"
+DATA_THUMBNAIL_FILENAME = "data_thumbnail.parquet"
 POINT_MAP_FILENAME = "point_map.fits"
 
 
@@ -198,6 +199,17 @@ def get_parquet_metadata_pointer(catalog_base_dir: str | Path | UPath) -> UPath:
         File Pointer to the catalog's `_metadata` file
     """
     return get_upath(catalog_base_dir) / DATASET_DIR / PARQUET_METADATA_FILENAME
+
+
+def get_data_thumbnail_pointer(catalog_base_dir: str | Path | UPath) -> UPath:
+    """Get file pointer to `data_thumbnail` parquet file
+
+    Args:
+        catalog_base_dir: pointer to base catalog directory
+    Returns:
+        File Pointer to the catalog's `data_thumbnail` file
+    """
+    return get_upath(catalog_base_dir) / DATASET_DIR / DATA_THUMBNAIL_FILENAME
 
 
 def get_point_map_file_pointer(catalog_base_dir: str | Path | UPath) -> UPath:

--- a/tests/hats/io/test_parquet_metadata.py
+++ b/tests/hats/io/test_parquet_metadata.py
@@ -10,6 +10,7 @@ from pyarrow.parquet import ParquetFile
 from hats.io import file_io, paths
 from hats.io.parquet_metadata import aggregate_column_statistics, per_pixel_statistics, write_parquet_metadata
 from hats.pixel_math.healpix_pixel import HealpixPixel
+from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN
 
 
 def test_write_parquet_metadata(tmp_path, small_sky_dir, small_sky_schema, check_parquet_schema):
@@ -77,7 +78,7 @@ def test_write_parquet_metadata_order1(
     assert len(data_thumbnail) == 4
     assert thumbnail.metadata.num_row_groups == 1
     assert data_thumbnail.schema.equals(small_sky_schema)
-    assert data_thumbnail.equals(data_thumbnail.sort_by("_healpix_29"))
+    assert data_thumbnail.equals(data_thumbnail.sort_by(SPATIAL_INDEX_COLUMN))
 
 
 def test_write_parquet_metadata_sorted(
@@ -115,7 +116,7 @@ def test_write_parquet_metadata_sorted(
     assert len(data_thumbnail) == 2
     assert thumbnail.metadata.num_row_groups == 1
     assert data_thumbnail.schema.equals(small_sky_schema)
-    assert data_thumbnail.equals(data_thumbnail.sort_by("_healpix_29"))
+    assert data_thumbnail.equals(data_thumbnail.sort_by(SPATIAL_INDEX_COLUMN))
 
 
 def test_write_index_parquet_metadata(tmp_path, check_parquet_schema):

--- a/tests/hats/io/test_parquet_metadata.py
+++ b/tests/hats/io/test_parquet_metadata.py
@@ -37,6 +37,12 @@ def test_write_parquet_metadata(tmp_path, small_sky_dir, small_sky_schema, check
         small_sky_schema,
         0,
     )
+    ## the data thumbnail was generated and it has 1 row
+    data_thumbnail_path = catalog_base_dir / "dataset" / "data_thumbnail.parquet"
+    assert data_thumbnail_path.exists()
+    data_thumbnail = pq.read_table(data_thumbnail_path)
+    assert data_thumbnail.schema.equals(small_sky_schema)
+    assert len(data_thumbnail) == 1
 
 
 def test_write_parquet_metadata_order1(
@@ -49,8 +55,7 @@ def test_write_parquet_metadata_order1(
         small_sky_order1_dir,
         temp_path,
     )
-
-    total_rows = write_parquet_metadata(temp_path)
+    total_rows = write_parquet_metadata(temp_path, create_thumbnail=False)
     assert total_rows == 131
     ## 4 row groups for 4 partitioned parquet files
     check_parquet_schema(
@@ -64,6 +69,8 @@ def test_write_parquet_metadata_order1(
         small_sky_schema,
         0,
     )
+    ## the data thumbnail was not generated
+    assert not (temp_path / "dataset" / "data_thumbnail.parquet").exists()
 
 
 def test_write_parquet_metadata_sorted(

--- a/tests/hats/io/test_parquet_metadata.py
+++ b/tests/hats/io/test_parquet_metadata.py
@@ -92,8 +92,8 @@ def test_write_parquet_metadata_sorted(
         temp_path,
     )
     ## Sneak in a test for the data thumbnail generation, specifying a
-    ## pixel threshold that is smaller than the number of partitions
-    total_rows = write_parquet_metadata(temp_path, pixel_threshold=2)
+    ## thumbnail threshold that is smaller than the number of partitions
+    total_rows = write_parquet_metadata(temp_path, thumbnail_threshold=2)
     assert total_rows == 131
     ## 4 row groups for 4 partitioned parquet files
     check_parquet_schema(


### PR DESCRIPTION
Generate the data thumbnail when writing the parquet metadata for catalogs. Based on work from Derek in https://github.com/astronomy-commons/hats-import/pull/532, this approach allows us to reuse this functionality on both hats-import and LSDB. Closes https://github.com/astronomy-commons/hats-import/issues/526.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation