### PR TITLE
Change default for `create_thumbnail` flag

### DIFF
--- a/src/hats/io/file_io/__init__.py
+++ b/src/hats/io/file_io/__init__.py
@@ -6,6 +6,7 @@ from .file_io import (
     make_directory,
     read_fits_image,
     read_parquet_dataset,
+    read_parquet_file,
     read_parquet_file_to_pandas,
     read_parquet_metadata,
     remove_directory,

--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -162,6 +162,19 @@ def read_parquet_metadata(file_pointer: str | Path | UPath, **kwargs) -> pq.File
     return parquet_file
 
 
+def read_parquet_file(file_pointer: str | Path | UPath, **kwargs) -> pq.ParquetFile:
+    """Read single parquet file.
+
+    Args:
+        file_pointer: location of parquet file
+        **kwargs: additional arguments to be passed to pyarrow.parquet.ParquetFile
+    """
+    file_pointer = get_upath(file_pointer)
+    if file_pointer is None or not file_pointer.exists():
+        raise FileNotFoundError("Parquet file does not exist")
+    return pq.ParquetFile(file_pointer.path, filesystem=file_pointer.fs, **kwargs)
+
+
 def read_parquet_dataset(source: str | Path | UPath, **kwargs) -> tuple[UPath, Dataset]:
     """Read parquet dataset from directory pointer or list of files.
 

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -80,7 +80,7 @@ def write_parquet_metadata(
 
     for single_file in dataset.files:
         relative_path = single_file[len(dataset_path) + 1 :]
-        file = pq.ParquetFile(dataset_subdir / relative_path)
+        file = file_io.read_parquet_file(dataset_subdir / relative_path)
         single_metadata = file.metadata
 
         # Users must set the file path of each chunk before combining the metadata.

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -24,7 +24,7 @@ def write_parquet_metadata(
     catalog_path: str | Path | UPath,
     order_by_healpix=True,
     output_path: str | Path | UPath | None = None,
-    create_thumbnail: bool = True,
+    create_thumbnail: bool = False,
     thumbnail_threshold: int = 1_000_000,
 ):
     """Generate parquet metadata, using the already-partitioned parquet files

--- a/tests/hats/io/test_parquet_metadata.py
+++ b/tests/hats/io/test_parquet_metadata.py
@@ -21,8 +21,7 @@ def test_write_parquet_metadata(tmp_path, small_sky_dir, small_sky_schema, check
         catalog_base_dir,
     )
 
-    ## Sneak in a test where we do not generate the thumbnail
-    total_rows = write_parquet_metadata(catalog_base_dir, create_thumbnail=False)
+    total_rows = write_parquet_metadata(catalog_base_dir)
     assert total_rows == 131
     check_parquet_schema(catalog_base_dir / "dataset" / "_metadata", small_sky_schema)
     ## _common_metadata has 0 row groups
@@ -55,7 +54,7 @@ def test_write_parquet_metadata_order1(
         small_sky_order1_dir,
         temp_path,
     )
-    total_rows = write_parquet_metadata(temp_path)
+    total_rows = write_parquet_metadata(temp_path, create_thumbnail=True)
     assert total_rows == 131
     ## 4 row groups for 4 partitioned parquet files
     check_parquet_schema(
@@ -93,7 +92,7 @@ def test_write_parquet_metadata_sorted(
     )
     ## Sneak in a test for the data thumbnail generation, specifying a
     ## thumbnail threshold that is smaller than the number of partitions
-    total_rows = write_parquet_metadata(temp_path, thumbnail_threshold=2)
+    total_rows = write_parquet_metadata(temp_path, create_thumbnail=True, thumbnail_threshold=2)
     assert total_rows == 131
     ## 4 row groups for 4 partitioned parquet files
     check_parquet_schema(


### PR DESCRIPTION
Considering only object/source catalogs will have the thumbnail, it's more convenient to have the default be False. I also fixed the creation of the `pq.ParquetFile` for it to be non-posix friendly.