### PR TITLE
Patch colorbar label in `plot_density()`

### DIFF
--- a/src/hats/inspection/visualize_catalog.py
+++ b/src/hats/inspection/visualize_catalog.py
@@ -83,7 +83,7 @@ def plot_density(catalog: Catalog, *, plot_title: str | None = None, order=None,
     col = ax.collections[0]
     plt.colorbar(
         col,
-        label=f"count / {unit} sq",
+        label=f"count / {unit}",
     )
     return fig, ax
 


### PR DESCRIPTION
## Change Description

The colorbar label on the figure created by `hats.inspection.plot_density()` has redundant units, like "deg2 sq" (screenshot below). This PR removes the "sq" so that the value of the `unit` kwarg will appear alone.

![Screenshot 2025-05-16 at 11 27 21 AM](https://github.com/user-attachments/assets/5db5d818-6007-463b-af6a-6017dac394d8)

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation