### PR TITLE
Skip pyarrow version 19.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numba>=0.58",
     "numpy>=2,<3", 
     "pandas>=2.0",
-    "pyarrow>=14.0.1",
+    "pyarrow>=14.0.1,!=19.0.0",
     "pydantic>=2.0",
     "scipy>=1.7.2",
     "typing-extensions>=4.3.0",


### PR DESCRIPTION
Skip the installation of pyarrow `19.0.0`. This version seems to have a bug that prevents datasets from being read with the error: `Repetition level histogram size mismatch`. Related to: https://github.com/astronomy-commons/hats-import/issues/555.