### PR TITLE
Do not swallow file system errors when reading catalogs.

### DIFF
--- a/tests/hats/catalog/loaders/test_read_hats.py
+++ b/tests/hats/catalog/loaders/test_read_hats.py
@@ -30,7 +30,7 @@ def test_read_hats_collection_main_catalog_invalid(small_sky_collection_dir, tmp
     collection_properties = CollectionProperties.read_from_dir(collection_base_dir)
     collection_properties.hats_primary_table_url = "small_sky_order1_margin"
     collection_properties.to_properties_file(collection_base_dir)
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(TypeError):
         read_hats(collection_base_dir)
 
 


### PR DESCRIPTION
Based on discussion with Sandro and Kostya, related to network instability on USDF, this change allows the file system errors to be more prominent.