### PR TITLE
raise error when plot_pixels is called on an empty region

### DIFF
--- a/src/hats/inspection/visualize_catalog.py
+++ b/src/hats/inspection/visualize_catalog.py
@@ -79,9 +79,12 @@ def plot_pixels(catalog: HealpixDataset, plot_title: str | None = None, **kwargs
     """
     pixels = catalog.get_healpix_pixels()
     default_title = f"Catalog pixel map - {catalog.catalog_name}"
+    title = default_title if plot_title is None else plot_title
+    if len(pixels) == 0:
+        raise ValueError(f"No pixels to plot for '{title}'. Cannot generate plot.")
     return plot_pixel_list(
         pixels=pixels,
-        plot_title=default_title if plot_title is None else plot_title,
+        plot_title=title,
         **kwargs,
     )
 

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -908,6 +908,17 @@ def test_catalog_plot_density_errors(small_sky_source_dir):
         plot_density(None)
 
 
+def test_plot_pixels_empty_region():
+    mock_catalog = MagicMock()
+    mock_catalog.catalog_name = "Test Empty Catalog"
+    mock_catalog.get_healpix_pixels.return_value = []
+    with pytest.raises(
+        ValueError,
+        match="No pixels to plot for 'Catalog pixel map - Test Empty Catalog'. Cannot generate plot.",
+    ):
+        plot_pixels(mock_catalog)
+
+
 def test_catalog_plot(small_sky_order1_catalog):
     fig, ax = plot_pixels(small_sky_order1_catalog)
     pixels = sorted(small_sky_order1_catalog.get_healpix_pixels())


### PR DESCRIPTION
raise value error if the region to plot has no pixel coverage. Closes #520 
