### PR TITLE
raise error when there are no remaining pixels to merge or plot

### DIFF
--- a/src/hats/inspection/visualize_catalog.py
+++ b/src/hats/inspection/visualize_catalog.py
@@ -79,9 +79,12 @@ def plot_pixels(catalog: HealpixDataset, plot_title: str | None = None, **kwargs
     """
     pixels = catalog.get_healpix_pixels()
     default_title = f"Catalog pixel map - {catalog.catalog_name}"
+    title = default_title if plot_title is None else plot_title
+    if len(pixels) == 0:
+        raise ValueError(f"No pixels to plot for '{title}'. Cannot generate plot.")
     return plot_pixel_list(
         pixels=pixels,
-        plot_title=default_title if plot_title is None else plot_title,
+        plot_title=title,
         **kwargs,
     )
 

--- a/src/hats/inspection/visualize_catalog.py
+++ b/src/hats/inspection/visualize_catalog.py
@@ -286,6 +286,8 @@ def cull_to_fov(depth_ipix_d: dict[int, tuple[np.ndarray, np.ndarray]], wcs):
 def _merge_too_small_pixels(depth_ipix_d: dict[int, tuple[np.ndarray, np.ndarray]], wcs):
     """Merges any pixels too small in a map to a lower order, with the map values within a lower order pixel
     being sampled"""
+    if not depth_ipix_d:
+        raise ValueError("No pixels remain. Cannot merge or plot an empty pixel map.")
     # Get the WCS cdelt giving the deg.px^(-1) resolution.
     cdelt = wcs.wcs.cdelt
     # Convert in rad.px^(-1)

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -908,6 +908,17 @@ def test_catalog_plot_density_errors(small_sky_source_dir):
         plot_density(None)
 
 
+def test_plot_pixels_empty_region():
+    mock_catalog = MagicMock()
+    mock_catalog.catalog_name = "Test Empty Catalog"
+    mock_catalog.get_healpix_pixels.return_value = []
+    with pytest.raises(
+        ValueError,
+        match="No pixels to plot for 'Catalog pixel map - Test Empty Catalog'. Cannot generate plot.",
+    ):
+        plot_pixels(mock_catalog)
+
+
 def test_catalog_plot(small_sky_order1_catalog):
     fig, ax = plot_pixels(small_sky_order1_catalog)
     pixels = sorted(small_sky_order1_catalog.get_healpix_pixels())

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -19,6 +19,7 @@ import hats.pixel_math.healpix_shim as hp
 from hats import read_hats
 from hats.inspection import plot_density, plot_pixels
 from hats.inspection.visualize_catalog import (
+    _merge_too_small_pixels,
     compute_healpix_vertices,
     cull_from_pixel_map,
     cull_to_fov,
@@ -908,7 +909,7 @@ def test_catalog_plot_density_errors(small_sky_source_dir):
         plot_density(None)
 
 
-def test_plot_pixels_empty_region():
+def test_plot_pixels_empty_region_or_no_remaining():
     mock_catalog = MagicMock()
     mock_catalog.catalog_name = "Test Empty Catalog"
     mock_catalog.get_healpix_pixels.return_value = []
@@ -917,6 +918,14 @@ def test_plot_pixels_empty_region():
         match="No pixels to plot for 'Catalog pixel map - Test Empty Catalog'. Cannot generate plot.",
     ):
         plot_pixels(mock_catalog)
+
+    empty_depth_ipix_d = {}
+    mock_wcs = MagicMock()
+    with pytest.raises(
+        ValueError,
+        match="No pixels remain. Cannot merge or plot an empty pixel map.",
+    ):
+        _merge_too_small_pixels(empty_depth_ipix_d, mock_wcs)
 
 
 def test_catalog_plot(small_sky_order1_catalog):


### PR DESCRIPTION
Raises value error when attempting to plot a catalog with no remaining pixels. Closes #468 
