### PR TITLE
Support margin filtering with larger Margin thresholds

### DIFF
--- a/src/hats/catalog/margin_cache/margin_catalog.py
+++ b/src/hats/catalog/margin_cache/margin_catalog.py
@@ -35,9 +35,8 @@ class MarginCatalog(HealpixDataset):
         max_order = moc.max_order
         max_order_size_arcsec = hp.order2mindist(max_order) * 60
         if self.catalog_info.margin_threshold > max_order_size_arcsec:
-            raise ValueError(
-                f"Cannot Filter Margin: Margin size {self.catalog_info.margin_threshold} is "
-                f"greater than the size of a pixel at the highest order {max_order}."
-            )
+            margin_thresh_arcmin = self.catalog_info.margin_threshold / 60
+            max_order = hp.avgsize2order(hp.mindist2avgsize(margin_thresh_arcmin))
+            moc = moc.degrade_to_order(max_order)
         search_moc = copy_moc(moc).add_neighbours()
         return super().filter_by_moc(search_moc)

--- a/src/hats/pixel_math/healpix_shim.py
+++ b/src/hats/pixel_math/healpix_shim.py
@@ -136,7 +136,7 @@ def avgsize2order(avg_size_arcmin: np.ndarray | float) -> np.ndarray | int:
     """
     avg_size_arcmin = np.asarray(avg_size_arcmin)
     order_float = np.log2(np.sqrt(np.pi / 3) / np.radians(avg_size_arcmin / 60.0))
-    return order_float.astype(np.int64)
+    return np.clip(order_float.astype(np.int64), a_min=0, a_max=29)
 
 
 def margin2order(margin_thr_arcmin: np.ndarray) -> np.ndarray:

--- a/src/hats/pixel_math/healpix_shim.py
+++ b/src/hats/pixel_math/healpix_shim.py
@@ -100,7 +100,7 @@ def avgsize2mindist(avg_size: np.ndarray) -> np.ndarray:
     return avg_size / 1.6
 
 
-def mindist2avgsize(mindist: np.ndarray) -> np.ndarray:
+def mindist2avgsize(mindist: np.ndarray | float) -> np.ndarray | float:
     """Get the average size for a given minimum distance between pixels
 
     We don't have the precise geometry of the healpix grid yet,
@@ -121,7 +121,7 @@ def mindist2avgsize(mindist: np.ndarray) -> np.ndarray:
     return mindist * 1.6
 
 
-def avgsize2order(avg_size_arcmin: np.ndarray) -> np.ndarray:
+def avgsize2order(avg_size_arcmin: np.ndarray | float) -> np.ndarray | int:
     """Get the largest order with average healpix size larger than avg_size_arcmin
 
     Parameters
@@ -134,9 +134,9 @@ def avgsize2order(avg_size_arcmin: np.ndarray) -> np.ndarray:
     np.ndarray of int
         The largest healpix order for which the average size is larger than avg_size_arcmin
     """
-    # resolution = sqrt(4pi / (12 * 4**order)) => order = log2(sqrt(4pi / 12) / resolution)
+    avg_size_arcmin = np.asarray(avg_size_arcmin)
     order_float = np.log2(np.sqrt(np.pi / 3) / np.radians(avg_size_arcmin / 60.0))
-    return np.array(order_float, dtype=int)
+    return order_float.astype(np.int64)
 
 
 def margin2order(margin_thr_arcmin: np.ndarray) -> np.ndarray:

--- a/tests/hats/catalog/margin_cache/test_margin_catalog.py
+++ b/tests/hats/catalog/margin_cache/test_margin_catalog.py
@@ -3,10 +3,10 @@ import os
 import pyarrow as pa
 import pytest
 
+import hats.pixel_math.healpix_shim as hp
 from hats.catalog import CatalogType, MarginCatalog, PartitionInfo, TableProperties
 from hats.loaders import read_hats
 from hats.pixel_math import HealpixPixel
-import hats.pixel_math.healpix_shim as hp
 
 
 def test_init_catalog(margin_catalog_info, margin_catalog_pixels):
@@ -88,7 +88,7 @@ def test_margin_filter_invalid_size(margin_catalog_info, margin_catalog_pixels):
     margin_catalog_info.margin_threshold = 100000
     catalog = MarginCatalog(margin_catalog_info, margin_catalog_pixels)
     pixels = [HealpixPixel(1, 28)]
-    max_order = max([p.order for p in pixels])
+    max_order = max(p.order for p in pixels)
     assert margin_catalog_info.margin_threshold > hp.order2mindist(max_order) * 60
     filtered_catalog = catalog.filter_from_pixel_list(pixels)
     assert filtered_catalog.get_healpix_pixels() == [

--- a/tests/hats/catalog/margin_cache/test_margin_catalog.py
+++ b/tests/hats/catalog/margin_cache/test_margin_catalog.py
@@ -6,6 +6,7 @@ import pytest
 from hats.catalog import CatalogType, MarginCatalog, PartitionInfo, TableProperties
 from hats.loaders import read_hats
 from hats.pixel_math import HealpixPixel
+import hats.pixel_math.healpix_shim as hp
 
 
 def test_init_catalog(margin_catalog_info, margin_catalog_pixels):
@@ -84,8 +85,17 @@ def test_margin_filter(margin_catalog_info, margin_catalog_pixels):
 
 
 def test_margin_filter_invalid_size(margin_catalog_info, margin_catalog_pixels):
-    margin_catalog_info.margin_threshold = 10000000
+    margin_catalog_info.margin_threshold = 100000
     catalog = MarginCatalog(margin_catalog_info, margin_catalog_pixels)
-    pixels = [HealpixPixel(1, 44)]
-    with pytest.raises(ValueError, match="greater than the size of a pixel"):
-        catalog.filter_from_pixel_list(pixels)
+    pixels = [HealpixPixel(1, 28)]
+    max_order = max([p.order for p in pixels])
+    assert margin_catalog_info.margin_threshold > hp.order2mindist(max_order) * 60
+    filtered_catalog = catalog.filter_from_pixel_list(pixels)
+    assert filtered_catalog.get_healpix_pixels() == [
+        HealpixPixel(0, 4),
+        HealpixPixel(0, 7),
+        HealpixPixel(1, 44),
+        HealpixPixel(1, 45),
+        HealpixPixel(1, 46),
+        HealpixPixel(1, 47),
+    ]


### PR DESCRIPTION
Because margin catalogs have points that aren’t actually in their pixels, we can’t just do a simple pixel tree search to filter them properly or we might miss points if the search region borders a pixel in the tree. So we extend the search moc by one pixel to catch these cases, but that doesn’t work if the moc order is smaller than the margin.

Previously we would error in this case, now the behavior is to degrade the moc order to perform the filter correctly.