### PR TITLE
Increase timeout for plotting test

### DIFF
--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -881,6 +881,7 @@ def test_plot_existing_wrong_axes():
     np.testing.assert_array_equal(col.get_array(), pix_map)
 
 
+@pytest.mark.timeout(20)
 def test_catalog_plot_density(small_sky_dir):
     """Test plotting pixel-density for on-disk catalog.
     Confirm plotting at lower order doesn't have a warning, and creates fewer plot paths."""


### PR DESCRIPTION
Tests for python 3.13. are currently [failing](https://github.com/astronomy-commons/hats/actions/runs/16814487181/job/47628275646) due to a timeout on `test_catalog_plot_density`.