### PR TITLE
Don't allow invalid parquet files.

### DIFF
--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -48,7 +48,6 @@ def write_parquet_metadata(
         sum of the number of rows in the dataset.
     """
     ignore_prefixes = [
-        "intermediate",
         "_common_metadata",
         "_metadata",
         "data_thumbnail",
@@ -56,11 +55,7 @@ def write_parquet_metadata(
 
     catalog_path = get_upath(catalog_path)
     dataset_subdir = catalog_path / "dataset"
-    (dataset_path, dataset) = file_io.read_parquet_dataset(
-        dataset_subdir,
-        ignore_prefixes=ignore_prefixes,
-        exclude_invalid_files=True,
-    )
+    (dataset_path, dataset) = file_io.read_parquet_dataset(dataset_subdir, ignore_prefixes=ignore_prefixes)
     metadata_collector = []
     # Collect the healpix pixels so we can sort before writing.
     healpix_pixels = []


### PR DESCRIPTION
Partial solution to https://github.com/astronomy-commons/hats-import/issues/569

Don't allow invalid files under the `dataset` directory. Since moving the parquet files under this directory, we can be even more strict about the set of files we believe might already exist in that folder.