### PR TITLE
Add citation to the docs

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,33 @@
+@ARTICLE{2025arXiv250102103C,
+       author = {{Caplar}, Neven and {Beebe}, Wilson and {Branton}, Doug and {Campos}, Sandro and {Connolly}, Andrew and {DeLucchi}, Melissa and {Jones}, Derek and {Juric}, Mario and {Kubica}, Jeremy and {Malanchev}, Konstantin and {Mandelbaum}, Rachel and {McGuire}, Sean},
+        title = "{Using LSDB to enable large-scale catalog distribution, cross-matching, and analytics}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2025,
+        month = jan,
+          eid = {arXiv:2501.02103},
+        pages = {arXiv:2501.02103},
+          doi = {10.48550/arXiv.2501.02103},
+archivePrefix = {arXiv},
+       eprint = {2501.02103},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250102103C},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2025arXiv250623955M,
+       author = {{Malanchev}, Konstantin and {DeLucchi}, Melissa and {Caplar}, Neven and {Malz}, Alex I. and {Beebe}, Wilson and {Branton}, Doug and {Campos}, Sandro and {Connolly}, Andrew and {Dai}, Mi and {Kubica}, Jeremy and {Lynn}, Olivia and {Mandelbaum}, Rachel and {McGuire}, Sean and {Aubourg}, Eric and {Blum}, Robert David and {Carlin}, Jeffrey L. and {Delgado}, Francisco and {Gangler}, Emmanuel and {Jannuzi}, Buell T. and {Jenness}, Tim and {Kang}, Yijung and {Kannawadi}, Arun and {Moniez}, Marc and {Plazas Malag{\'o}n}, Andr{\'e}s A. and {van Reeven}, Wouter and {Sanmartim}, David and {Urbach}, Elana K. and {Wood-Vasey}, W.~M.},
+        title = "{Variability-finding in Rubin Data Preview 1 with LSDB}",
+      journal = {arXiv e-prints},
+     keywords = {Instrumentation and Methods for Astrophysics, Solar and Stellar Astrophysics},
+         year = 2025,
+        month = jun,
+          eid = {arXiv:2506.23955},
+        pages = {arXiv:2506.23955},
+          doi = {10.48550/arXiv.2506.23955},
+archivePrefix = {arXiv},
+       eprint = {2506.23955},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250623955M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ See related projects:
 See the [contribution guide](https://hats.readthedocs.io/en/stable/guide/contributing.html)
 for completed installation instructions and contribution best practices.
 
+## Citation
+
+If you use HATS in your work, please cite the conference proceedings: 
+["Using LSDB to enable large-scale catalog distribution, cross-matching, and analytics"](https://ui.adsabs.harvard.edu/abs/2025arXiv250102103C). 
+
+If you use Rubin Data Preview 1 (DP1) with HATS, please also cite: ["Variability-finding in Rubin Data Preview 1 with LSDB"](https://ui.adsabs.harvard.edu/abs/2025arXiv250623955M).
+
+Find full citation information [here](./CITATION.bib).
+
 ## Acknowledgements
 
 This project is supported by Schmidt Sciences.

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,66 @@
+About
+==========================
+
+HATS is an open source project and is free for all to use. It is released under the liberal terms of the
+`BSD 3-Clause License <https://github.com/astronomy-commons/hats/blob/main/LICENSE>`_.
+
+Citation
+--------------------------
+
+If HATS has been significant in your research, and you would like to
+acknowledge the project in your academic publication, we suggest citing 
+the conference proceedings:
+
+.. code-block:: bash
+
+    @ARTICLE{2025arXiv250102103C,
+        author        = {{Caplar}, Neven and {Beebe}, Wilson and {Branton}, Doug and {Campos}, Sandro and {Connolly}, Andrew and {DeLucchi}, Melissa and {Jones}, Derek and {Juric}, Mario and {Kubica}, Jeremy and {Malanchev}, Konstantin and {Mandelbaum}, Rachel and {McGuire}, Sean},
+        title         = "{Using LSDB to enable large-scale catalog distribution, cross-matching, and analytics}",
+        journal       = {arXiv e-prints},
+        keywords      = {Astrophysics - Instrumentation and Methods for Astrophysics},
+        year          = 2025,
+        month         = jan,
+        eid           = {arXiv:2501.02103},
+        pages         = {arXiv:2501.02103},
+        doi           = {10.48550/arXiv.2501.02103},
+        archivePrefix = {arXiv},
+        eprint        = {2501.02103},
+        primaryClass  = {astro-ph.IM},
+        adsurl        = {https://ui.adsabs.harvard.edu/abs/2025arXiv250102103C},
+        adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+    }
+
+If you used Rubin Data Preview 1 (DP1) with HATS, please also consider citing the following paper:
+
+.. code-block:: bash
+
+    @ARTICLE{2025arXiv250623955M,
+        author        = {{Malanchev}, Konstantin and {DeLucchi}, Melissa and {Caplar}, Neven and {Malz}, Alex I. and {Beebe}, Wilson and {Branton}, Doug and {Campos}, Sandro and {Connolly}, Andrew and {Dai}, Mi and {Kubica}, Jeremy and {Lynn}, Olivia and {Mandelbaum}, Rachel and {McGuire}, Sean and {Aubourg}, Eric and {Blum}, Robert David and {Carlin}, Jeffrey L. and {Delgado}, Francisco and {Gangler}, Emmanuel and {Jannuzi}, Buell T. and {Jenness}, Tim and {Kang}, Yijung and {Kannawadi}, Arun and {Moniez}, Marc and {Plazas Malag{\'o}n}, Andr{\'e}s A. and {van Reeven}, Wouter and {Sanmartim}, David and {Urbach}, Elana K. and {Wood-Vasey}, W.~M.},
+        title         = "{Variability-finding in Rubin Data Preview 1 with LSDB}",
+        journal       = {arXiv e-prints},
+        keywords      = {Instrumentation and Methods for Astrophysics, Solar and Stellar Astrophysics},
+        year          = 2025,
+        month         = jun,
+        eid           = {arXiv:2506.23955},
+        pages         = {arXiv:2506.23955},
+        doi           = {10.48550/arXiv.2506.23955},
+        archivePrefix = {arXiv},
+        eprint        = {2506.23955},
+        primaryClass  = {astro-ph.IM},
+        adsurl        = {https://ui.adsabs.harvard.edu/abs/2025arXiv250623955M},
+        adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+    }
+
+
+Acknowledgements
+-------------------------------------------------------------------------------
+
+This project is supported by Schmidt Sciences.
+
+This project is based upon work supported by the National Science Foundation
+under Grant No. AST-2003196.
+
+This project acknowledges support from the DIRAC Institute in the Department of 
+Astronomy at the University of Washington. The DIRAC Institute is supported 
+through generous gifts from the Charles and Lisa Simonyi Fund for Arts and 
+Sciences, and the Washington Research Foundation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,18 +25,20 @@ operations on top of these utilities. Some known extensions:
 
 .. toctree::
    :maxdepth: 1
-   :caption: Overview
+   :caption: Using HATS
 
-   getting_started
-   guide/directory_scheme
+   Getting Started <getting_started>
+   Directory Scheme <guide/directory_scheme>
    Notebooks <notebooks>
+   API Reference <autoapi/index>
 
 .. toctree::
    :maxdepth: 1
-   :caption: Developers
+   :caption: Project
 
-   guide/contributing
-   API Reference <autoapi/index>
+   About & Citation <citation>
+   Contribution Guide <guide/contributing>
+
 
 Getting Started
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Add citations to the HATS documentation. 

It also tidies up the index links a bit so they match those on the LSDB documentation.