### PR TITLE
Clarify return type of read-parquet_dataset.

### DIFF
--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -190,7 +190,9 @@ def read_parquet_file(file_pointer: str | Path | UPath, **kwargs) -> pq.ParquetF
     return pq.ParquetFile(file_pointer.path, filesystem=file_pointer.fs, **kwargs)
 
 
-def read_parquet_dataset(source: str | Path | UPath, **kwargs) -> tuple[UPath, Dataset]:
+def read_parquet_dataset(
+    source: str | Path | UPath | list[str | Path | UPath], **kwargs
+) -> tuple[str | list[str], Dataset]:
     """Read parquet dataset from directory pointer or list of files.
 
     Note that pyarrow.dataset reads require that directory pointers don't contain a
@@ -208,10 +210,9 @@ def read_parquet_dataset(source: str | Path | UPath, **kwargs) -> tuple[UPath, D
         and the dataset read from disk.
     """
     if pd.api.types.is_list_like(source) and len(source) > 0:
-        sample_pointer = source[0]
-        sample_pointer = get_upath(sample_pointer)
-        file_system = sample_pointer.fs
-        source = [str(path) for path in source]
+        upaths = [get_upath(path) for path in source]
+        file_system = upaths[0].fs
+        source = [path.path for path in upaths]
     else:
         source = get_upath(source)
         file_system = source.fs
@@ -223,7 +224,7 @@ def read_parquet_dataset(source: str | Path | UPath, **kwargs) -> tuple[UPath, D
         format="parquet",
         **kwargs,
     )
-    return (str(source), dataset)
+    return (source, dataset)
 
 
 def write_parquet_metadata(

--- a/tests/hats/io/file_io/test_file_io.py
+++ b/tests/hats/io/file_io/test_file_io.py
@@ -132,15 +132,16 @@ def test_read_parquet_data(tmp_path):
 
 
 def test_read_parquet_dataset(small_sky_dir, small_sky_order1_dir):
-    (_, ds) = read_parquet_dataset(small_sky_dir / "dataset" / "Norder=0")
+    (paths, ds) = read_parquet_dataset(small_sky_dir / "dataset" / "Norder=0")
 
     assert ds.count_rows() == 131
 
-    (_, ds) = read_parquet_dataset([small_sky_dir / "dataset" / "Norder=0" / "Dir=0" / "Npix=11.parquet"])
+    (paths, ds) = read_parquet_dataset([small_sky_dir / "dataset" / "Norder=0" / "Dir=0" / "Npix=11.parquet"])
 
     assert ds.count_rows() == 131
+    assert len(paths) == 1
 
-    (_, ds) = read_parquet_dataset(
+    (paths, ds) = read_parquet_dataset(
         [
             small_sky_order1_dir / "dataset" / "Norder=1" / "Dir=0" / "Npix=44.parquet",
             small_sky_order1_dir / "dataset" / "Norder=1" / "Dir=0" / "Npix=45.parquet",
@@ -148,8 +149,8 @@ def test_read_parquet_dataset(small_sky_dir, small_sky_order1_dir):
             small_sky_order1_dir / "dataset" / "Norder=1" / "Dir=0" / "Npix=47.parquet",
         ]
     )
-
     assert ds.count_rows() == 131
+    assert len(paths) == 4
 
 
 def test_write_point_map_roundtrip(small_sky_order1_dir, tmp_path):


### PR DESCRIPTION
Closes #540 

Return value is either a string or a list of strings.

There is a note in the docstring of this method about pyarrow/parquet expecting a particular format for the path string that is passed in, and this returns the same value as sent with the reading request. However, when passing in multiple paths, our behavior was fairly wrong, and should do the proper path manipulation for all elements (but I'm still hoping they're all on the same filesystem).

I will add some tests in hats-cloudtests, showing the expected behavior on non-local filesystems.