### PR TITLE
Fix skymap reading on Windows

### DIFF
--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -256,15 +256,14 @@ def read_fits_image(map_file_pointer: str | Path | UPath) -> np.ndarray:
         value at each index corresponds to the number of objects found at the healpix pixel.
     """
     map_file_pointer = get_upath(map_file_pointer)
-    _tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    try:
+    with tempfile.NamedTemporaryFile(delete=False) as _tmp_file:
         with map_file_pointer.open("rb") as _map_file:
             _tmp_file.write(_map_file.read())
-        _tmp_file.close()
-        return Skymap.from_fits(_tmp_file.name).values
+        tmp_path = _tmp_file.name
+    try:
+        return Skymap.from_fits(tmp_path).values
     finally:
-        _tmp_file.close()
-        os.unlink(_tmp_file.name)
+        os.unlink(tmp_path)
 
 
 def write_fits_image(histogram: np.ndarray, map_file_pointer: str | Path | UPath):


### PR DESCRIPTION
In cdshealpix v0.7.2 `Skymap.from_fits` now opens our named temporary file (https://github.com/cds-astro/cds-healpix-python/pull/38), and our Windows unit tests are [failing](https://github.com/astronomy-commons/lsdb/actions/runs/18659163924/job/53196512665). I re-ran the [Windows unit tests](https://github.com/astronomy-commons/lsdb/actions/runs/18663899835) as well as the [hats-cloudtests tests](https://github.com/astronomy-commons/hats-cloudtests/actions/runs/18663922640) to confirm that this change does not tamper with remote file access.
