### PR TITLE
Update pyarrow pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ dependencies = [
     "numba>=0.58",
     "numpy>=2,<3", 
     "pandas>=2.0",
-    "pyarrow>=14.0.1,!=19.0.0",
+    # NOTE: package PINNED at:
+    # !=19.0.0 due to https://github.com/astronomy-commons/hats/pull/516
+    # !=21.0.0 due to https://github.com/astronomy-commons/lsdb/issues/974
+    "pyarrow>=14.0.1,!=19.0.0,!=21.0.0",
     "pydantic>=2.0",
     "scipy>=1.7.2",
     "typing-extensions>=4.3.0",


### PR DESCRIPTION
Update versions of pyarrow to be skipped. Handle versions here instead of separately in lsdb/hats-import.