### PR TITLE
Add windows specific dependency to pyarrow pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # NOTE: package PINNED at:
     # !=19.0.0 due to https://github.com/astronomy-commons/hats/pull/516
     # !=21.0.0 due to https://github.com/astronomy-commons/lsdb/issues/974
-    "pyarrow>=14.0.1,!=19.0.0,<21.0.0; platform_system == 'Windows'",
+    "pyarrow>=14.0.1,!=19.0.0,!=21.0.0; platform_system == 'Windows'",
     "pyarrow>=14.0.1,!=19.0.0; platform_system != 'Windows'",
 
     "pydantic>=2.0",


### PR DESCRIPTION
The `pyarrow!=21.0.0` is only needed for windows platforms due to astronomy-commons/lsdb#974. Updates the dependencies to allow newer pyarrow versions not on windows.