### PR TITLE
Read pixel parquet more efficiently

### DIFF
--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -375,9 +375,12 @@ def read_parquet_file_to_pandas(
     file_pointer: str | Path | UPath
         File Pointer to a parquet file or a directory containing parquet files
     is_dir : bool | None
-        If True, we know the pointer is for a pixel directory and therefore there
-        is no need to call `upath.is_dir()`, as it is an expensive operation.
-        (Default value = None)
+        If True, the pointer represents a pixel directory, otherwise, the pointer
+        represents a file. In both cases there is no need to check the pointer's
+        content type. If `is_dir` is None (default), this method will resort to
+        `upath.is_dir()` to identify the type of pointer. Inferring the type for
+        HTTP is particularly expensive because it requires downloading the contents
+        of the pointer in its entirety.
     **kwargs
         Additional arguments to pass to pandas read_parquet method
 
@@ -388,20 +391,24 @@ def read_parquet_file_to_pandas(
     """
     file_pointer = get_upath(file_pointer)
 
-    if _parquet_precache_all_bytes(file_pointer):  # pragma: no cover
-        return npd.read_parquet(BytesIO(file_pointer.read_bytes()), partitioning=None, **kwargs)
-
-    file_pointers = file_pointer.path
-
     # If we are trying to read a remote directory, we need to send the explicit list of files instead.
     # We don't want to get the list unnecessarily because it can be expensive.
     if is_dir is None:
         is_dir = file_pointer.is_dir()
     if file_pointer.protocol not in ("", "file") and is_dir:  # pragma: no cover
         file_pointers = [f.path for f in file_pointer.iterdir() if f.is_file()]
+        return npd.read_parquet(
+            file_pointers,
+            filesystem=file_pointer.fs,
+            partitioning=None,  # Avoid the ArrowTypeError described in #367
+            **kwargs,
+        )
+
+    if _parquet_precache_all_bytes(file_pointer):  # pragma: no cover
+        return npd.read_parquet(BytesIO(file_pointer.read_bytes()), partitioning=None, **kwargs)
 
     return npd.read_parquet(
-        file_pointers,
+        file_pointer.path,
         filesystem=file_pointer.fs,
         partitioning=None,  # Avoid the ArrowTypeError described in #367
         **kwargs,


### PR DESCRIPTION
Pass an argument to the `read_parquet_file_to_pandas` call that indicates if the pixels leaves are directories or not (we know beforehand with the `npix_suffix`). This allows us to skip the `UPath.is_dir()` step which downloads the entire contents of the path just to check if its type is directory/file. Part of #592 . 