### PR TITLE
Add length attributes to partition info

### DIFF
--- a/src/hats/catalog/partition_info.py
+++ b/src/hats/catalog/partition_info.py
@@ -45,6 +45,16 @@ class PartitionInfo:
         max_pixel = np.max(self.pixel_list)
         return max_pixel.order
 
+    def __len__(self):
+        """The number of partitions.
+
+        Returns
+        -------
+        int
+            The number of partition pixels.
+        """
+        return len(self.pixel_list)
+
     def write_to_file(
         self,
         partition_info_file: str | Path | UPath | None = None,

--- a/tests/hats/catalog/test_partition_info.py
+++ b/tests/hats/catalog/test_partition_info.py
@@ -34,6 +34,7 @@ def test_load_partition_info_small_sky_order1(small_sky_order1_dir):
     partition_info_file = paths.get_parquet_metadata_pointer(small_sky_order1_dir)
     partitions = PartitionInfo.read_from_file(partition_info_file)
 
+    assert len(partitions) == 4
     order_pixel_pairs = partitions.get_healpix_pixels()
     assert len(order_pixel_pairs) == 4
     expected = [


### PR DESCRIPTION
In writing a unit test in hats-import, I was surprised I couldn't do `assert len(partition_info) == 14`, so now I can.