### PR TITLE
Normalize `include_stats` ordering in `per_pixel_statistics`

### DIFF
--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -363,7 +363,7 @@ def aggregate_column_statistics(
     return frame
 
 
-# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-positional-arguments,too-many-statements
 def per_pixel_statistics(
     metadata_file: str | Path | UPath,
     exclude_hats_columns: bool = True,
@@ -451,6 +451,7 @@ def per_pixel_statistics(
         for stat in include_stats:
             if stat not in all_stats:
                 raise ValueError(f"include_stats must be from list {all_stats} (found {stat})")
+        include_stats = [stat for stat in all_stats if stat in include_stats]
         int_stats = [stat for stat in int_stats if stat in include_stats]
 
     stat_mask = np.array([ind for ind, stat in enumerate(all_stats) if stat in include_stats])

--- a/tests/hats/io/test_parquet_metadata.py
+++ b/tests/hats/io/test_parquet_metadata.py
@@ -357,9 +357,13 @@ def test_per_pixel_statistics_multi_index(small_sky_order1_dir):
 def test_per_pixel_statistics_include_stats(small_sky_order1_dir):
     partition_info_file = paths.get_parquet_metadata_pointer(small_sky_order1_dir)
 
-    result_frame = per_pixel_statistics(partition_info_file, include_stats=["row_count"])
-    # 5 = 5 columns * 1 stat per column
-    assert result_frame.shape == (4, 5)
+    result_frame = per_pixel_statistics(partition_info_file, include_stats=["disk_bytes", "memory_bytes"])
+    # 10 = 5 columns * 2 stats per column
+    assert result_frame.shape == (4, 10)
+
+    # The order of the stats should not matter
+    result_frame_2 = per_pixel_statistics(partition_info_file, include_stats=["memory_bytes", "disk_bytes"])
+    pd.testing.assert_frame_equal(result_frame, result_frame_2)
 
     result_frame = per_pixel_statistics(
         partition_info_file, include_stats=["row_count"], include_columns=["id"]


### PR DESCRIPTION
The `per_pixel_statistics` method was sensitive to the order of the elements in `include_stats`.  This PR normalizes their order internally, so the results should now be the same regardless of how the stats are ordered by the user.