### PR TITLE
Add `moc_sky_fraction` to `TableProperties` to parse with correct type

### DIFF
--- a/src/hats/catalog/dataset/table_properties.py
+++ b/src/hats/catalog/dataset/table_properties.py
@@ -101,6 +101,8 @@ class TableProperties(BaseModel):
     hats_max_bytes: Optional[int] = Field(default=None, alias="hats_max_bytes")
     """Maximum number of bytes in any partition of the catalog."""
 
+    moc_sky_fraction: Optional[float] = Field(default=None)
+
     ## Allow any extra keyword args to be stored on the properties object.
     model_config = ConfigDict(extra="allow", populate_by_name=True, use_enum_values=True)
 

--- a/tests/hats/catalog/dataset/test_table_properties.py
+++ b/tests/hats/catalog/dataset/test_table_properties.py
@@ -130,7 +130,7 @@ def test_copy_and_update():
 
     prop_c = initital_properties.copy_and_update(moc_sky_fraction=0.54)
     assert initital_properties != prop_c
-    assert prop_c.__pydantic_extra__["moc_sky_fraction"] == pytest.approx(0.54)
+    assert prop_c.moc_sky_fraction == pytest.approx(0.54)
 
 
 def test_read_from_dir_branches(
@@ -212,3 +212,8 @@ def test_provenance_dict(small_sky_dir, tmp_path):
     assert properties["hats_release_date"].startswith("20")
     assert properties["hats_version"].startswith("v")
     assert properties["foo"] == "bar"
+
+
+def test_datatype_parsing(small_sky_dir):
+    properties = TableProperties.read_from_dir(small_sky_dir)
+    assert isinstance(properties.moc_sky_fraction, float)


### PR DESCRIPTION
Fixes #579 