### PR TITLE
Generate README.md for a catalog collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "astropy>=7.0.0",
     "cdshealpix>=0.7.0",
     "fsspec>=2023.10.0", # Used for abstract filesystems
+    "jinja2>=3.0.0", # Used for summary file templating
     "jproperties>=2.0.0",
     "mocpy>=0.19.0",
     "nested-pandas>=0.6.6",
@@ -35,7 +36,6 @@ dependencies = [
     "pyarrow>=14.0.1,!=19.0.0; platform_system != 'Windows'",
 
     "pydantic>=2.0",
-    "PyYAML", # Used for Hugging Face metadata, version from astropy requirements
     "scipy>=1.7.2",
     "typing-extensions>=4.3.0",
     "universal-pathlib>=0.3.1",
@@ -56,6 +56,7 @@ dev = [
     "pytest-cov", # Used to report total code coverage
     "pytest-mock", # Used to mock objects in tests
     "pytest-timeout", # Used to test for code efficiency
+    "PyYAML", # Used to test Hugging-Face YAML metadata generation
 ]
 plotting = [
     "matplotlib>=3.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pyarrow>=14.0.1,!=19.0.0; platform_system != 'Windows'",
 
     "pydantic>=2.0",
+    "PyYAML", # Used for Hugging Face metadata, version from astropy requirements
     "scipy>=1.7.2",
     "typing-extensions>=4.3.0",
     "universal-pathlib>=0.3.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/lincc-frameworks/nested-pandas.git@main
+datasets

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -155,23 +155,27 @@ def generate_hugging_face_yaml_metadata(collection: CatalogCollection) -> str:
     configs = [
         {
             "config_name": "default",
-            "data_dir": props.hats_primary_table_url,
+            # We use string concatenation here, because we always need "/", not current
+            # OS-specific separator.
+            "data_dir": f"{props.hats_primary_table_url}/dataset",
         }
     ]
-    for margin in props.all_margins or []:
-        configs.append(
-            {
-                "config_name": margin,
-                "data_dir": margin,
-            }
-        )
-    for index_field, index_dir in (props.all_indexes or {}).items():
-        configs.append(
-            {
-                "config_name": index_field,
-                "data_dir": index_dir,
-            }
-        )
+    if props.all_margins is not None:
+        for margin in props.all_margins:
+            configs.append(
+                {
+                    "config_name": margin,
+                    "data_dir": f"{margin}/dataset",
+                }
+            )
+    if props.all_indexes is not None:
+        for index in props.all_indexes.values():
+            configs.append(
+                {
+                    "config_name": index,
+                    "data_dir": f"{index}/dataset",
+                }
+            )
 
     data = {
         "configs": configs,

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -1,0 +1,180 @@
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from upath import UPath
+
+from hats.catalog.catalog_collection import CatalogCollection
+from hats.io.file_io import get_upath
+from hats.loaders.read_hats import read_hats
+
+
+def write_collection_summary_file(
+    collection_path: str | Path | UPath,
+    *,
+    fmt: Literal["markdown"],
+    filename: str | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    huggingface_metadata: bool = False,
+) -> UPath:
+    """Write a summary readme file for a HATS catalog.
+
+    Parameters
+    ----------
+    collection_path: str | Path | UPath
+        The path to the HATS collection.
+    fmt : str
+        The format of the summary file. Currently only "markdown" is supported.
+    filename: str | None, default=None
+        The name of the summary file. If None, default depends on a `fmt`:
+        - "README.md" for "markdown" format.
+    title : str | None, default=None
+        Title of the summary document. By default, generated based on catalog
+        name. This default is a subject of frequent changes, do not rely on it.
+    description : str | None, default=None :
+        Description of the catalog. By default, generated based on catalog
+        metadata. The default is a subject of frequent changes, do not rely
+        on it.
+    huggingface_metadata : bool, optional
+        Whether to include Hugging Face specific metadata header in
+        the markdown file, by default False. Supported only when
+        `fmt="markdown"`.
+
+    Returns
+    -------
+    UPath
+        The path to the written summary file.
+
+    Notes
+    -----
+
+    1. Not all options are supported for all formats.
+    2. Default string generation is a subject of frequent changes, including
+       patch releases, so do not rely on them for the reproducible results.
+       However, we are trying to make them as useful as possible.
+    """
+    collection_path = get_upath(collection_path)
+    if fmt != "markdown" and huggingface_metadata:
+        raise ValueError("`huggingface_metadata=True` is supported only for `fmt='markdown'`")
+
+    collection = read_hats(collection_path)
+    if not isinstance(collection, CatalogCollection):
+        raise ValueError(
+            f"The provided path '{collection_path}' contains a HATS catalog, but not a collection.'"
+        )
+
+    name = collection.collection_properties.name
+    if title is None:
+        title = f"{name} HATS catalog"
+    if description is None:
+        # Should be extended in the future to include more details.
+        description = f"This is the `{name}` HATS collection."
+
+    match fmt:
+        case "markdown":
+            content = generate_markdown_collection_summary(
+                collection=collection,
+                title=title,
+                description=description,
+                huggingface_metadata=huggingface_metadata,
+            )
+        case _:
+            raise ValueError(f"Unsupported format: {fmt=}")
+
+    if filename is None:
+        match fmt:
+            case "markdown":
+                filename = "README.md"
+            case _:
+                raise ValueError(f"Unsupported format: {fmt=}")
+
+    output_path = collection_path / filename
+
+    with output_path.open("w") as f:
+        f.write(content)
+
+    return output_path
+
+
+def generate_markdown_collection_summary(
+    collection: CatalogCollection,
+    *,
+    title: str,
+    description: str,
+    huggingface_metadata: bool,
+) -> str:
+    """Generate markdown summary content for a HATS collection.
+
+    Parameters
+    ----------
+    title : str
+        Title of the markdown document.
+    description : str
+        Description of the catalog.
+    huggingface_metadata : bool
+        Whether to include Hugging Face specific metadata header in
+        the markdown file.
+    """
+    snippets = []
+    if huggingface_metadata:
+        hf_yaml = generate_hugging_face_yaml_metadata(collection)
+        snippets.append(f"---\n" f"{hf_yaml}\n" f"---\n")
+    snippets.append(f"# {title}")
+    snippets.append(f"{description}")
+
+    # Should be extended in the future to include sections like:
+    # - Load code examples
+    # - File structure
+    # - Statistics
+    # - Column schema
+    # - Sky maps
+    # See https://github.com/astronomy-commons/hats/issues/615
+
+    return "\n".join(snippets)
+
+
+def generate_hugging_face_yaml_metadata(collection: CatalogCollection) -> str:
+    """Generate Hugging Face specific YAML "frontmatter" for a HATS collection.
+
+    Parameters
+    ----------
+    collection : CatalogCollection
+        The HATS collection for which to generate the metadata.
+
+    Returns
+    -------
+    str
+        The generated YAML metadata as a string.
+    """
+    props = collection.collection_properties
+
+    # Configs specify different datasets within a single HF repository.
+    # We set default config to be the HATS catalog, and others to be
+    # other collection catalogs like margin and index.
+    configs = [
+        {
+            "config_name": "default",
+            "data_dir": props.hats_primary_table_url,
+        }
+    ]
+    for margin in props.all_margins or []:
+        configs.append(
+            {
+                "config_name": margin,
+                "data_dir": margin,
+            }
+        )
+    for index_field, index_dir in (props.all_indexes or {}).items():
+        configs.append(
+            {
+                "config_name": index_field,
+                "data_dir": index_dir,
+            }
+        )
+
+    data = {
+        "configs": configs,
+        "tags": ["astronomy"],
+    }
+    return yaml.dump(data, sort_keys=False, default_flow_style=False)

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -114,6 +114,18 @@ def test_write_collection_summary_file_invalid_format(tmp_path, small_sky_collec
         )
 
 
+def test_write_collection_summary_file_unsupported_fits_format(tmp_path, small_sky_collection_dir):
+    """Test that fits format raises an error for unsupported format"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    with pytest.raises(ValueError, match="Unsupported format"):
+        write_collection_summary_file(
+            collection_base_dir,
+            fmt="fits",  # Not supported
+        )
+
+
 def test_generate_markdown_collection_summary_basic(small_sky_collection_dir):
     """Test generating markdown summary content"""
     collection = read_hats(small_sky_collection_dir)

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -1,0 +1,226 @@
+"""Tests for summary file generation"""
+
+import shutil
+
+import pytest
+import yaml
+
+from hats.io.summary_file import (
+    generate_hugging_face_yaml_metadata,
+    generate_markdown_collection_summary,
+    write_collection_summary_file,
+)
+from hats.loaders import read_hats
+
+
+def test_write_collection_summary_file_markdown(tmp_path, small_sky_collection_dir):
+    """Test writing a basic markdown summary file for a collection"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    output_path = write_collection_summary_file(
+        collection_base_dir,
+        fmt="markdown",
+    )
+
+    assert output_path.exists()
+    assert output_path.name == "README.md"
+    assert output_path.parent == collection_base_dir
+
+    # Check that the file has basic content
+    content = output_path.read_text()
+    assert "small_sky_o1_collection HATS catalog" in content
+    assert "This is the `small_sky_o1_collection` HATS collection." in content
+
+
+def test_write_collection_summary_file_custom_filename(tmp_path, small_sky_collection_dir):
+    """Test writing a summary file with a custom filename"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    output_path = write_collection_summary_file(
+        collection_base_dir,
+        fmt="markdown",
+        filename="CUSTOM.md",
+    )
+
+    assert output_path.exists()
+    assert output_path.name == "CUSTOM.md"
+    assert output_path.parent == collection_base_dir
+
+
+def test_write_collection_summary_file_custom_title_description(tmp_path, small_sky_collection_dir):
+    """Test writing a summary file with custom title and description"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    custom_title = "My Custom Title"
+    custom_description = "This is a custom description for the catalog."
+
+    output_path = write_collection_summary_file(
+        collection_base_dir,
+        fmt="markdown",
+        title=custom_title,
+        description=custom_description,
+    )
+
+    content = output_path.read_text()
+    assert custom_title in content
+    assert custom_description in content
+
+
+def test_write_collection_summary_file_with_huggingface_metadata(tmp_path, small_sky_collection_dir):
+    """Test writing a markdown summary file with Hugging Face metadata"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    output_path = write_collection_summary_file(
+        collection_base_dir,
+        fmt="markdown",
+        huggingface_metadata=True,
+    )
+
+    content = output_path.read_text()
+    # Check for YAML frontmatter
+    assert content.startswith("---\n")
+    assert "configs:" in content
+    assert "tags:" in content
+    assert "astronomy" in content
+
+
+def test_write_collection_summary_file_invalid_format(tmp_path, small_sky_collection_dir):
+    """Test that invalid format raises an error"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    with pytest.raises(ValueError, match="Unsupported format"):
+        write_collection_summary_file(
+            collection_base_dir,
+            fmt="xml",  # Not supported
+        )
+
+
+def test_generate_markdown_collection_summary_basic(small_sky_collection_dir):
+    """Test generating markdown summary content"""
+    collection = read_hats(small_sky_collection_dir)
+
+    content = generate_markdown_collection_summary(
+        collection=collection,
+        title="Test Title",
+        description="Test Description",
+        huggingface_metadata=False,
+    )
+
+    assert "# Test Title" in content
+    assert "Test Description" in content
+    assert "---" not in content  # No YAML frontmatter
+
+
+def test_generate_markdown_collection_summary_with_huggingface(small_sky_collection_dir):
+    """Test generating markdown summary content with Hugging Face metadata"""
+    collection = read_hats(small_sky_collection_dir)
+
+    content = generate_markdown_collection_summary(
+        collection=collection,
+        title="Test Title",
+        description="Test Description",
+        huggingface_metadata=True,
+    )
+
+    assert content.startswith("---\n")
+    assert "# Test Title" in content
+    assert "Test Description" in content
+
+
+def test_generate_hugging_face_yaml_metadata(small_sky_collection_dir):
+    """Test generating Hugging Face YAML metadata for a collection"""
+    collection = read_hats(small_sky_collection_dir)
+
+    yaml_content = generate_hugging_face_yaml_metadata(collection)
+
+    # Parse the YAML to verify structure
+    data = yaml.safe_load(yaml_content)
+
+    assert "configs" in data
+    assert "tags" in data
+    assert "astronomy" in data["tags"]
+
+    # Check configs structure
+    configs = data["configs"]
+    assert isinstance(configs, list)
+    assert len(configs) > 0
+
+    # Check default config
+    default_config = configs[0]
+    assert default_config["config_name"] == "default"
+    assert default_config["data_dir"] == "small_sky_order1"
+
+    # Check margin configs
+    margin_configs = [
+        c
+        for c in configs
+        if c["config_name"] in ["small_sky_order1_margin", "small_sky_order1_margin_10arcs"]
+    ]
+    assert len(margin_configs) == 2
+
+    # Check index configs
+    index_configs = [c for c in configs if c["config_name"] == "id"]
+    assert len(index_configs) == 1
+    assert index_configs[0]["data_dir"] == "small_sky_order1_id_index"
+
+
+def test_generate_hugging_face_yaml_metadata_no_margins(tmp_path, small_sky_collection_dir):
+    """Test generating Hugging Face YAML metadata for a collection without margins"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    # Remove margins from collection properties
+    collection = read_hats(collection_base_dir)
+    collection.collection_properties.all_margins = None
+    collection.collection_properties.default_margin = None
+    collection.collection_properties.to_properties_file(collection_base_dir)
+
+    # Re-read the collection
+    collection = read_hats(collection_base_dir)
+
+    yaml_content = generate_hugging_face_yaml_metadata(collection)
+    data = yaml.safe_load(yaml_content)
+
+    # Check that only default config exists (no margin configs)
+    configs = data["configs"]
+    config_names = [c["config_name"] for c in configs]
+    assert "default" in config_names
+    assert "small_sky_order1_margin" not in config_names
+
+
+def test_generate_hugging_face_yaml_metadata_no_indexes(tmp_path, small_sky_collection_dir):
+    """Test generating Hugging Face YAML metadata for a collection without indexes"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    # Remove indexes from collection properties
+    collection = read_hats(collection_base_dir)
+    collection.collection_properties.all_indexes = None
+    collection.collection_properties.default_index = None
+    collection.collection_properties.to_properties_file(collection_base_dir)
+
+    # Re-read the collection
+    collection = read_hats(collection_base_dir)
+
+    yaml_content = generate_hugging_face_yaml_metadata(collection)
+    data = yaml.safe_load(yaml_content)
+
+    # Check that only default and margin configs exist (no index configs)
+    configs = data["configs"]
+    config_names = [c["config_name"] for c in configs]
+    assert "default" in config_names
+    assert "id" not in config_names
+
+
+def test_write_collection_summary_file_with_non_collection_raises_error(small_sky_dir):
+    """Test that ValueError is raised when a non-collection catalog path is passed"""
+    with pytest.raises(ValueError, match="contains a HATS catalog, but not a collection"):
+        write_collection_summary_file(
+            small_sky_dir,
+            fmt="markdown",
+        )


### PR DESCRIPTION
Initial implementation of #615 (not closing it yet).

**Description**

Adds `hats.io.summary_file.write_collection_summary_file` method to create a catalog root "index" file with a catalog collection description. Currently it supports `fmt="markdown"` only, but we also plan to add "html" (for HTTP storage, like data.lsdb.io/hats/<catalog>/index.html) and "json" (machine-readable, e.g., for data.lsdb.io generation) formats in the future.

Currently, the generated `README.md` is very minimalistic and includes three parts only: optional Hugging Face metadata (to enable https://github.com/UniverseTBD/mmu-hdf-to-hats/issues/30), title, and a very short description. This is to be extended in future PRs.

**New dependencies**

Both are for the Hugging Face functionality

- `jinja2` is added as a "main" dependency, which adds two packages to our dependency tree
- `pyyaml` is added as a `[dev]` dependency, but it is actually already included with `astropy`
- `datasets` is added to `requirements.txt` for testing Hugging Face metadata. I tried to add it to `[dev]`, but I cannot make it work with test-lowest-deps. **Let me know if there is a better solution**