### PR TITLE
Add hats_max_rows back to table_properties; change unit test to match

### DIFF
--- a/src/hats/catalog/dataset/table_properties.py
+++ b/src/hats/catalog/dataset/table_properties.py
@@ -98,6 +98,9 @@ class TableProperties(BaseModel):
     skymap_alt_orders: Optional[list[int]] = Field(default=None, alias="hats_skymap_alt_orders")
     """Nested Order (K) of the healpix skymaps stored in altnernative skymap.K.fits."""
 
+    hats_max_rows: Optional[int] = Field(default=None, alias="hats_max_rows")
+    """Maximum number of rows in any partition of the catalog."""
+
     hats_max_bytes: Optional[int] = Field(default=None, alias="hats_max_bytes")
     """Maximum number of bytes in any partition of the catalog."""
 

--- a/tests/hats/catalog/dataset/test_table_properties.py
+++ b/tests/hats/catalog/dataset/test_table_properties.py
@@ -156,8 +156,7 @@ def test_read_from_dir_branches(
 def test_extra_dict():
     extra_properties = {
         "hats_copyright": "LINCC Frameworks 2024",
-        "hats_estsize": 10000000,
-        "hats_max_rows": 1000000,
+        "hats_estsize": 10_000_000,
     }
     table_properties = TableProperties(
         catalog_name="foo",
@@ -166,6 +165,8 @@ def test_extra_dict():
         extra_columns="a , b",
         indexing_column="a",
         primary_catalog="bar",
+        hats_max_rows=1_000_000,
+        hats_max_bytes=5_000_000,
         **extra_properties,
     )
 


### PR DESCRIPTION
Closes #618

From initial commit in [this PR](https://github.com/astronomy-commons/hats/pull/617), where adding hats_max_rows to table_properties made this unit test was failing because that made hats_max_rows no longer an "extra property" (see [log](https://github.com/astronomy-commons/hats/actions/runs/20467441180/job/58814558145)). 

Looks like the fix was extraordinarily simple! Though I recall there was also the typing issue mucking with the cloud tests, so I guess for me it was just a matter of returning to things with fresh eyes.
