### PR TITLE
Extend generated README.md

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,10 @@
 # Changes here will be overwritten by Copier
-_commit: v2.1.2
+_commit: v2.2.0
 _src_path: gh:lincc-frameworks/python-project-template
 author_email: lincc-frameworks-team@lists.lsst.org
 author_name: LINCC Frameworks
 create_example_module: false
-custom_install: true
+custom_install: custom
 enforce_style:
 - pylint
 - black
@@ -16,6 +16,7 @@ include_docs: true
 include_notebooks: true
 mypy_type_checking: none
 package_name: hats
+project_description: Hierarchical Adaptive Tiling Scheme Catalog
 project_license: BSD
 project_name: hats
 project_organization: astronomy-commons

--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -12,6 +12,13 @@ assignees: ''
 **Environment Information**
 
 
+<details>
+<summary>Traceback</summary>
+
+FILL IN YOUR STACK TRACE HERE
+
+</details>
+
 **Before submitting**
 Please check the following:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,63 +1,13 @@
-<!-- 
-Thank you for your contribution to the repo :)
-
-Pull Request (PR) Instructions:
-Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.
-
-Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
- 
-How to link to a PR:
-https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
--->
-
 ## Change Description
 <!--- 
-Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".
-
-If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
+Closes #???
 -->
-- [ ] My PR includes a link to the issue that I am addressing
-
-
 
 ## Solution Description
-<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
-
 
 
 ## Code Quality
-- [ ] I have read the Contribution Guide
+- [ ] I have read the Contribution Guide and agree to the Code of Conduct
 - [ ] My code follows the code style of this project
 - [ ] My code builds (or compiles) cleanly without any errors or warnings
 - [ ] My code contains relevant comments and necessary documentation
-
-## Project-Specific Pull Request Checklists
-<!--- Please only use the checklist that apply to your change type(s) -->
-
-### Bug Fix Checklist
-- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
-- [ ] My change includes a breaking change
-  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
-
-### New Feature Checklist
-- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
-- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
-- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
-- [ ] My change includes a breaking change
-  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
-
-### Documentation Change Checklist
-- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
-
-### Build/CI Change Checklist
-- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
-- [ ] If this is a new CI setup, I have added the associated badge to the README
-
-<!-- ### Version Change Checklist [For Future Use] -->
-
-### Other Change Checklist
-- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
-- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
-- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
-- [ ] My change includes a breaking change
-  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -64,6 +64,9 @@ jobs:
           uv pip compile --resolution=lowest-direct pyproject.toml -o requirements_lowest.txt
         fi
         uv pip install --constraint=requirements_lowest.txt -e .[dev]
+    - name: List dependencies
+      run: |
+        pip list
     - name: Run unit tests with pytest
       run: |
         source venv/bin/activate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     # This hook should always pass. It will print a message if the local version 
     # is out of date.
   - repo: https://github.com/lincc-frameworks/pre-commit-hooks
-    rev: v0.1.2
+    rev: v0.2.2
     hooks:
       - id: check-lincc-frameworks-template-version
         name: Check template version
@@ -23,7 +23,7 @@ repos:
         entry: jupyter nbconvert --clear-output
     # Prevents committing directly branches named 'main' and 'master'.
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: no-commit-to-branch
         name: Prevent main branch commits
@@ -41,13 +41,13 @@ repos:
         description: Verify that pyproject.toml adheres to the established schema.
     # Verify that GitHub workflows are well formed
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.0
+    rev: 0.36.1
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
     # Automatically sort the imports used in .py files
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 7.0.0
     hooks:
       - id: isort
         name: Run isort
@@ -85,7 +85,7 @@ repos:
           ]
     # Analyze the code style and report code that doesn't adhere.
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 26.1.0
     hooks:
       - id: black-jupyter
         name: Format code using black
@@ -95,32 +95,15 @@ repos:
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.12
-    # Make sure Sphinx can build the documentation while explicitly omitting 
-    # notebooks from the docs, so users don't have to wait through the execution 
-    # of each notebook or each commit. By default, these will be checked in the 
-    # GitHub workflows.
-  - repo: local
+  - repo: https://github.com/lincc-frameworks/pre-commit-hooks
+    rev: v0.2.2
     hooks:
-      - id: sphinx-build
-        name: Build documentation with Sphinx
-        entry: sphinx-build
-        language: system
-        always_run: true
-        exclude_types: [file, symlink]
+      - id: pre-executed-nb-never-execute
+        name: Check pre-executed notebooks
+        files: ^docs/pre_executed/.*\.ipynb$
+        verbose: true
         args:
-          [
-            "-M", # Run sphinx in make mode, so we can use -D flag later
-                  # Note: -M requires next 3 args to be builder, source, output
-            "html", # Specify builder
-            "./docs", # Source directory of documents
-            "./_readthedocs", # Output directory for rendered documents
-            "-T", # Show full trace back on exception
-            "-E", # Don't use saved env; always read all files
-            "-d", # Flag for cached environment and doctrees
-            "./docs/_build/doctrees", # Directory
-            "-D", # Flag to override settings in conf.py
-            "exclude_patterns=notebooks/*,_build", # Exclude notebooks and build dir from pre-commit
-          ]
+          ["docs/pre_executed/"]
     # Run unit tests, verify that they pass. Note that coverage is run against
     # the ./src directory here because that is what will be committed. In the
     # github workflow script, the coverage is run against the installed package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "astropy>=7.0.0",
     "cdshealpix>=0.8.0",
     "fsspec>=2023.10.0", # Used for abstract filesystems
+    "human_readable", # Used for pretty-printing file sizes
     "jinja2>=3.0.0", # Used for summary file templating
     "jproperties>=2.0.0",
     "mocpy>=0.19.0",
@@ -73,6 +74,9 @@ requires = [
     "setuptools_scm>=6.2", # Gets release version from git. Makes it available programmatically
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.package-data]
+hats = ["io/templates/*.jinja2"]
 
 [tool.setuptools_scm]
 write_to = "src/hats/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ omit=["src/hats/_version.py"]
 
 [tool.black]
 line-length = 110
-target-version = ["py311"]
 [tool.isort]
 profile = "black"
 line_length = 110

--- a/src/hats/catalog/partition_info.py
+++ b/src/hats/catalog/partition_info.py
@@ -120,7 +120,7 @@ class PartitionInfo:
                 "data_thumbnail",
             ]
             dataset_subdir = paths.dataset_directory(catalog_base_dir)
-            (_, dataset) = file_io.read_parquet_dataset(dataset_subdir, ignore_prefixes=ignore_prefixes)
+            _, dataset = file_io.read_parquet_dataset(dataset_subdir, ignore_prefixes=ignore_prefixes)
 
             # Iterate through files to get the healpix pixels.
             for file in dataset.files:

--- a/src/hats/io/parquet_metadata.py
+++ b/src/hats/io/parquet_metadata.py
@@ -96,7 +96,7 @@ def write_parquet_metadata(
 
     catalog_path = get_upath(catalog_path)
     dataset_subdir = catalog_path / "dataset"
-    (dataset_path, dataset) = file_io.read_parquet_dataset(dataset_subdir, ignore_prefixes=ignore_prefixes)
+    dataset_path, dataset = file_io.read_parquet_dataset(dataset_subdir, ignore_prefixes=ignore_prefixes)
     metadata_collector = []
     # Collect the healpix pixels so we can sort before writing.
     healpix_pixels = []

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -1,11 +1,17 @@
+import importlib.resources
 from pathlib import Path
 from typing import Literal
 
+import human_readable
 import jinja2
+import nested_pandas as npd
+import pandas as pd
 from upath import UPath
 
 from hats.catalog.catalog_collection import CatalogCollection
-from hats.io.file_io import get_upath
+from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset
+from hats.io import get_common_metadata_pointer, get_partition_info_pointer, templates
+from hats.io.file_io import get_upath, read_parquet_file_to_pandas
 from hats.loaders.read_hats import read_hats
 
 
@@ -14,8 +20,10 @@ def write_collection_summary_file(
     *,
     fmt: Literal["markdown"],
     filename: str | None = None,
-    title: str | None = None,
+    output_dir: str | Path | UPath | None = None,
+    name: str | None = None,
     description: str | None = None,
+    uri: str | None = None,
     huggingface_metadata: bool = False,
     jinja2_template: str | None = None,
 ) -> UPath:
@@ -30,21 +38,28 @@ def write_collection_summary_file(
     filename: str | None, default=None
         The name of the summary file. If None, default depends on a `fmt`:
         - "README.md" for "markdown" format.
-    title : str | None, default=None
-        Title of the summary document. By default, generated based on catalog
-        name. This default is a subject of frequent changes, do not rely on it.
+    output_dir : str | Path | UPath | None
+        The root directory to output the summary file to. If None, the summary
+        file would be written to the `collection_path`. If the directory does
+        not exist, it would be created.
+    name : str | None, default=None
+        Human-readable name of the catalog. By default, generated based on
+        catalog metadata.
     description : str | None, default=None
         Description of the catalog. By default, generated based on catalog
-        metadata. The default is a subject of frequent changes, do not rely
-        on it.
+        metadata.
+    uri : str | None, default=None
+        URI of the catalog to use for the code-snippet examples. Not validated.
+        If None, a placeholder would be used.
     huggingface_metadata : bool, default=False
         Whether to include Hugging Face specific metadata header in
         the Markdown file, by default False. Supported only when
         `fmt="markdown"`.
     jinja2_template : str, default=NOne
         `jinja2` template string to use for generating the summary file.
-        If provided, it would override the default template:
-        - `DEFAULT_MD_TEMPLATE` for `fmt="markdown"`.
+        If provided, it would override the default template from these
+        functions:
+        - `default_md_template()` for `fmt="markdown"`.
 
     Returns
     -------
@@ -67,19 +82,19 @@ def write_collection_summary_file(
             f"The provided path '{collection_path}' contains a HATS catalog, but not a collection.'"
         )
 
-    name = collection.collection_properties.name
-    if title is None:
-        title = f"{name} HATS catalog"
+    if name is None:
+        name = collection.collection_properties.name
+
     if description is None:
-        # Should be extended in the future to include more details.
-        description = f"This is the `{name}` HATS collection."
+        description = f"This is the collection of HATS catalogs representing {name}."
 
     match fmt:
         case "markdown":
             content = generate_markdown_collection_summary(
                 collection=collection,
-                title=title,
+                name=name,
                 description=description,
+                uri=uri,
                 huggingface_metadata=huggingface_metadata,
                 jinja2_template=jinja2_template,
             )
@@ -93,7 +108,9 @@ def write_collection_summary_file(
             case _:
                 raise ValueError(f"Unsupported format: {fmt=}")
 
-    output_path = collection_path / filename
+    output_dir = collection_path if output_dir is None else get_upath(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / filename
 
     with output_path.open("w") as f:
         f.write(content)
@@ -101,43 +118,23 @@ def write_collection_summary_file(
     return output_path
 
 
-# Should be extended in the future to include sections like:
-# - Load code examples
-# - File structure
-# - Statistics
-# - Column schema
-# - Sky maps
-# See https://github.com/astronomy-commons/hats/issues/615
-DEFAULT_MD_TEMPLATE = """
-{%- if huggingface_metadata %}
----
-configs:
-- config_name: default
-  data_dir: {{primary_table}}/dataset
-{%- for margin in all_margins %}
-- config_name: {{margin}}
-  data_dir: {{margin}}/dataset
-{%- endfor %}
-{%- for index in all_indexes %}
-- config_name: {{index}}
-  data_dir: {{index}}/dataset
-{%- endfor %}
-tags:
-- astronomy
----
-{%- endif %}
+def default_md_template() -> str:
+    """Get the default Jinja2 template string for generating Markdown summary files.
 
-# {{title}}
-
-{{description}}
-"""
+    Returns
+    -------
+    str
+        The default Jinja2 template string.
+    """
+    return importlib.resources.read_text(templates, "default_md_template.jinja2")
 
 
 def generate_markdown_collection_summary(
     collection: CatalogCollection,
     *,
-    title: str,
+    name: str,
     description: str,
+    uri: str | None = None,
     huggingface_metadata: bool,
     jinja2_template: str | None = None,
 ) -> str:
@@ -145,7 +142,7 @@ def generate_markdown_collection_summary(
 
     Parameters
     ----------
-    title : str
+    name : str
         Title of the Markdown document.
     description : str
         Description of the catalog.
@@ -155,20 +152,94 @@ def generate_markdown_collection_summary(
     jinja2_template : str | None
 
     """
-    props = collection.collection_properties
+    col_props = collection.collection_properties
+    catalog = collection.main_catalog
+    cat_props = catalog.catalog_info
+
     env = jinja2.Environment(undefined=jinja2.StrictUndefined)
     if jinja2_template is None:
-        jinja2_template = DEFAULT_MD_TEMPLATE
+        jinja2_template = default_md_template()
     template = env.from_string(jinja2_template)
 
-    all_margins = props.all_margins or []
-    all_indexes = list((props.all_indexes or {}).values())
+    has_partition_info = get_partition_info_pointer(collection.main_catalog_dir).exists()
+    uri = uri or "<PATH_TO_CATALOG>"
+    margin_thresholds = collection.get_margin_thresholds()
+
+    if (common_metadata := get_common_metadata_pointer(collection.main_catalog_dir)).exists():
+        empty_nf = read_parquet_file_to_pandas(common_metadata)
+    else:
+        empty_nf = None
+
+    has_nested_columns = False if empty_nf is None else len(empty_nf.nested_columns) > 0
+
+    metadata_table = _gen_md_metadata_table(
+        catalog, total_columns=None if empty_nf is None else empty_nf.shape[1]
+    )
+
+    column_table = (
+        pd.DataFrame()
+        if empty_nf is None
+        else _gen_md_column_table(empty_nf, cat_props.default_columns or [])
+    )
 
     return template.render(
-        title=title,
+        name=name,
         description=description,
-        primary_table=props.hats_primary_table_url,
-        all_margins=all_margins,
-        all_indexes=all_indexes,
+        col_props=col_props,
+        cat_props=cat_props,
+        has_partition_info=has_partition_info,
+        margin_thresholds=margin_thresholds,
+        uri=uri,
         huggingface_metadata=huggingface_metadata,
+        has_default_columns=cat_props.default_columns is not None,
+        has_nested_columns=has_nested_columns,
+        metadata_table=metadata_table,
+        column_table=column_table,
     )
+
+
+def _gen_md_metadata_table(catalog: HealpixDataset, total_columns: int | None) -> dict[str, object]:
+    props = catalog.catalog_info
+    has_healpix_column = props.healpix_column is not None
+
+    metadata_table = {}
+    if props.total_rows is not None:
+        metadata_table["Number of rows"] = f"{props.total_rows:,}"
+    if total_columns is not None:
+        key = "Number of columns"
+        # Exclude HEALPix index columns from the count
+        value = f"{total_columns - int(has_healpix_column):,}"
+        if props.default_columns is not None:
+            key = "Number of columns (default columns)"
+            value = f"{value} ({len(props.default_columns):,})"
+        metadata_table[key] = value
+    metadata_table["Number of partitions"] = f"{len(catalog.get_healpix_pixels()):,}"
+    if (hats_estsize_kb := props.extra_dict().get("hats_estsize")) is not None:
+        metadata_table["Size on disk"] = human_readable.file_size(int(hats_estsize_kb) * 1024, binary=True)
+    if (hats_builder := props.extra_dict().get("hats_builder")) is not None:
+        metadata_table["HATS Builder"] = hats_builder
+    return metadata_table
+
+
+def _gen_md_column_table(nf: npd.NestedFrame, default_columns: list[str]) -> pd.DataFrame:
+    default_columns = frozenset(default_columns)
+
+    column = []
+    dtype = []
+    default = []
+    nested_into = []
+
+    for name, dt in nf.dtypes.items():
+        if isinstance(dt, npd.NestedDtype):
+            subcolumns = nf.get_subcolumns(name)
+            column.extend(subcolumns)
+            dtype.extend(f"list[{nf[sc].dtype.pyarrow_dtype}]" for sc in subcolumns)
+            default.extend(name in default_columns or sc in default_columns for sc in subcolumns)
+            nested_into.extend([name] * len(subcolumns))
+        else:
+            column.append(name)
+            dtype.append(str(dt.pyarrow_dtype))
+            nested_into.append(None)
+            default.append(name in default_columns)
+
+    return pd.DataFrame({"column": column, "dtype": dtype, "default": default, "nested_into": nested_into})

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -49,8 +49,9 @@ def write_collection_summary_file(
         Description of the catalog. By default, generated based on catalog
         metadata.
     uri : str | None, default=None
-        URI of the catalog to use for the code-snippet examples. Not validated.
-        If None, a placeholder would be used.
+        URI of the catalog to use for the hyperlinks and code-snippet examples.
+        Not validated. If None, a placeholder would be used for
+        the code-snippets.
     huggingface_metadata : bool, default=False
         Whether to include Hugging Face specific metadata header in
         the Markdown file, by default False. Supported only when
@@ -134,7 +135,7 @@ def generate_markdown_collection_summary(
     *,
     name: str,
     description: str,
-    uri: str | None = None,
+    uri: str | None,
     huggingface_metadata: bool,
     jinja2_template: str | None = None,
 ) -> str:
@@ -146,6 +147,10 @@ def generate_markdown_collection_summary(
         Title of the Markdown document.
     description : str
         Description of the catalog.
+    uri : str | None
+        URI of the catalog to use for the hyperlinks and code-snippet examples.
+        Not validated. If None, a placeholder would be used for
+        the code-snippets.
     huggingface_metadata : bool
         Whether to include Hugging Face specific metadata header in
         the Markdown file.
@@ -162,7 +167,6 @@ def generate_markdown_collection_summary(
     template = env.from_string(jinja2_template)
 
     has_partition_info = get_partition_info_pointer(collection.main_catalog_dir).exists()
-    uri = uri or "<PATH_TO_CATALOG>"
     margin_thresholds = collection.get_margin_thresholds()
 
     if (common_metadata := get_common_metadata_pointer(collection.main_catalog_dir)).exists():

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -55,7 +55,7 @@ def write_collection_summary_file(
         Whether to include Hugging Face specific metadata header in
         the Markdown file, by default False. Supported only when
         `fmt="markdown"`.
-    jinja2_template : str, default=NOne
+    jinja2_template : str, default=None
         `jinja2` template string to use for generating the summary file.
         If provided, it would override the default template from these
         functions:

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -143,6 +143,8 @@ def generate_markdown_collection_summary(
 
     Parameters
     ----------
+    collection : CatalogCollection
+        HATS collection to generate summary for.
     name : str
         Title of the Markdown document.
     description : str

--- a/src/hats/io/templates/default_md_template.jinja2
+++ b/src/hats/io/templates/default_md_template.jinja2
@@ -22,7 +22,7 @@ tags:
 
 ### Access the catalog
 
-It is recommended to use [LSDB](https://lsdb.io) Python framework to access HATS catalogs.
+We recommended the use of the [LSDB](https://lsdb.io) Python framework to access HATS catalogs.
 LSDB can be installed via `pip install lsdb` or `conda install conda-forge::lsdb`,
 see more details [in the docs](https://docs.lsdb.io/).
 The following code provides a minimal example of opening this catalog:
@@ -33,8 +33,7 @@ import lsdb
 catalog = lsdb.open_catalog("{{uri}}")
 ```
 
-Since each catalog in this collection is represented as a separate [Apache Parquet dataset](https://arrow.apache.org/docs/python/dataset.html),
-which may be accessed with a variety of tools, including `pandas`, `pyarrow`, `dask`, `Spark`, `DuckDB`, etc.
+Each catalog in this collection is represented as a separate [Apache Parquet dataset](https://arrow.apache.org/docs/python/dataset.html) and can be accessed with a variety of tools, including `pandas`, `pyarrow`, `dask`, `Spark`, `DuckDB`.
 
 ### File structure
 

--- a/src/hats/io/templates/default_md_template.jinja2
+++ b/src/hats/io/templates/default_md_template.jinja2
@@ -1,0 +1,104 @@
+{%- if huggingface_metadata %}
+---
+configs:
+- config_name: default
+  data_dir: {{col_props.hats_primary_table_url}}/dataset
+{%- for margin in (col_props.all_margins or []) %}
+- config_name: {{margin}}
+  data_dir: {{margin}}/dataset
+{%- endfor %}
+{%- for index in (col_props.all_indexes or {}).values() %}
+- config_name: {{index}}
+  data_dir: {{index}}/dataset
+{%- endfor %}
+tags:
+- astronomy
+---
+{%- endif %}
+
+# {{name}} HATS Catalog Collection
+
+{{description}}
+
+### Access the catalog
+
+It is recommended to use [LSDB](https://lsdb.io) Python framework to access HATS catalogs.
+LSDB can be installed via `pip install lsdb` or `conda install conda-forge::lsdb`,
+see more details [in the docs](https://docs.lsdb.io/).
+The following code provides a minimal example of opening this catalog:
+
+```python
+import lsdb
+
+catalog = lsdb.open_catalog("{{uri}}")
+```
+
+Since each catalog in this collection is represented as a separate [Apache Parquet dataset](https://arrow.apache.org/docs/python/dataset.html),
+which may be accessed with a variety of tools, including `pandas`, `pyarrow`, `dask`, `Spark`, `DuckDB`, etc.
+
+### File structure
+
+This catalog is represented by the following files and directories:
+- [`collection.properties`](./collection.properties) — textual metadata file describing the HATS collection of catalogs
+- [`{{col_props.hats_primary_table_url}}/`](./{{col_props.hats_primary_table_url}}/) — main HATS catalog directory
+  - [`dataset/`](./{{col_props.hats_primary_table_url}}/dataset/) — Apache Parquet dataset directory for the main catalog
+    - ... parquet metadata and data files in sub directories ...
+  - [`hats.properties`](./{{col_props.hats_primary_table_url}}/hats.properties) — textual metadata file describing the main HATS catalog
+  {%- if has_partition_info %}
+  - [`partition_info.csv`](./{{col_props.hats_primary_table_url}}/partition_info.csv) — CSV file with a list of catalog HEALPix tiles (catalog partitions)
+  {%- endif %}
+  {%- if cat_props.skymap_order %}
+  - [`skymap.fits`](./{{col_props.hats_primary_table_url}}/skymap.fits) — HEALPix skymap FITS file with row-counts per HEALPix tile of fixed order {{cat_props.skymap_order}}
+  {%- for alt_order in (cat_props.skymap_alt_orders or []) %}
+  - [`skymap.{{alt_order}}.fits`](./{{col_props.hats_primary_table_url}}/skymap.{{alt_order}}.fits) — Same, but for order {{alt_order}}
+  {%- endfor %}
+  {%- endif %}
+{%- if col_props.default_margin %}
+- [`{{col_props.default_margin}}/`](./{{col_props.hats_primary_table_url}}/{{col_props.default_margin}}/) — margin catalog to ensure data completeness in cross-matching, margin threshold is {{ '%.1f' % margin_thresholds[col_props.default_margin]}} arcseconds
+  - ... margin catalog files and directories ...
+{%- endif %}
+{%- for margin in (col_props.all_margins or []) if margin != col_props.default_margin %}
+- [`{{margin}}/`](./{{margin}}/) — margin catalog to ensure data completeness in cross-matching, margin threshold is {{ '%.1f' % margin_thresholds[margin]}} arcseconds
+  - ... margin catalog files and directories ...
+{%- endfor %}
+{%- if col_props.default_index %}{%- set dir = col_props.all_indexes[col_props.default_index] %}
+- [`{{dir}}/`](./{{dir}}/) — default secondary index catalog for fast queries over column `{{col_props.default_index}}`
+  - ... index catalog files and directories ...
+{%- endif %}
+{%- for column, dir in (col_props.all_indexes or {}).items() if column != col_props.default_index %}
+- [`{{dir}}/`](./{{dir}}/) — secondary index catalog for fast queries over column `column`
+  - ... index catalog files and directories ...
+{%- endfor %}
+
+### Catalog metadata
+
+Metadata of the main HATS catalog, excluding margins and indexes:
+
+|{%- for name in metadata_table.keys() %} **{{name}}** |{%- endfor %}
+|{%- for _ in metadata_table %} --- |{%- endfor %}
+|{%- for value in metadata_table.values() %} {{value}} |{%- endfor %}
+
+{% if not column_table.empty %}
+### Catalog columns
+
+The main HATS catalog contains the following columns:
+
+| **Name** | {% for col in column_table.column %} **`{{col}}`** |{% endfor %}
+| --- | {% for _ in column_table.column %} --- |{% endfor %}
+| **Data Type** | {% for value in column_table.dtype %} `{{value}}` |{% endfor %}
+{% if has_default_columns -%}
+| **Default?** | {%- for value in column_table.default %} {{ "Yes" if value else "No" }} |{%- endfor %}
+{%- endif %}
+{% if has_nested_columns -%}
+| **Nested?** | {%- for value in column_table.nested_into %} {{ value or "-" }} |{%- endfor %}
+{%- endif %}
+{%if has_default_columns %}
+"Default" indicates whether the column is included when loading the catalog with `lsdb.open_catalog()`
+without specifying any columns to load.
+The list of default columns is available in the [`hats.properties`](./{{col_props.hats_primary_table_url}}/hats.properties) file.
+{% endif %}
+{%if has_nested_columns %}
+"Nested" indicates whether the column is stored as a nested field inside another "struct" column.
+{% endif %}
+
+{% endif %}

--- a/src/hats/io/templates/default_md_template.jinja2
+++ b/src/hats/io/templates/default_md_template.jinja2
@@ -30,7 +30,7 @@ The following code provides a minimal example of opening this catalog:
 ```python
 import lsdb
 
-catalog = lsdb.open_catalog("{{uri}}")
+catalog = lsdb.open_catalog("{{uris["collection"]}}")
 ```
 
 Each catalog in this collection is represented as a separate [Apache Parquet dataset](https://arrow.apache.org/docs/python/dataset.html) and can be accessed with a variety of tools, including `pandas`, `pyarrow`, `dask`, `Spark`, `DuckDB`.
@@ -38,34 +38,27 @@ Each catalog in this collection is represented as a separate [Apache Parquet dat
 ### File structure
 
 This catalog is represented by the following files and directories:
-- [`collection.properties`](./collection.properties) — textual metadata file describing the HATS collection of catalogs
-- [`{{col_props.hats_primary_table_url}}/`](./{{col_props.hats_primary_table_url}}/) — main HATS catalog directory
-  - [`dataset/`](./{{col_props.hats_primary_table_url}}/dataset/) — Apache Parquet dataset directory for the main catalog
+
+- [`collection.properties`]({{uris["collection"]}}/collection.properties) — textual metadata file describing the HATS collection of catalogs
+- [`{{uris["primary"]["name"]}}`]({{uris["primary"]["uri"]}}) — main HATS catalog directory
+  - [`dataset/`]({{uris["primary"]["uri"]}}/dataset/) — Apache Parquet dataset directory for the main catalog
     - ... parquet metadata and data files in sub directories ...
-  - [`hats.properties`](./{{col_props.hats_primary_table_url}}/hats.properties) — textual metadata file describing the main HATS catalog
+  - [`hats.properties`]({{uris["primary"]["uri"]}}/hats.properties) — textual metadata file describing the main HATS catalog
   {%- if has_partition_info %}
-  - [`partition_info.csv`](./{{col_props.hats_primary_table_url}}/partition_info.csv) — CSV file with a list of catalog HEALPix tiles (catalog partitions)
+  - [`partition_info.csv`]({{uris["primary"]["uri"]}}/partition_info.csv) — CSV file with a list of catalog HEALPix tiles (catalog partitions)
   {%- endif %}
   {%- if cat_props.skymap_order %}
-  - [`skymap.fits`](./{{col_props.hats_primary_table_url}}/skymap.fits) — HEALPix skymap FITS file with row-counts per HEALPix tile of fixed order {{cat_props.skymap_order}}
+  - [`skymap.fits`]({{uris["primary"]["uri"]}}/skymap.fits) — HEALPix skymap FITS file with row-counts per HEALPix tile of fixed order {{cat_props.skymap_order}}
   {%- for alt_order in (cat_props.skymap_alt_orders or []) %}
-  - [`skymap.{{alt_order}}.fits`](./{{col_props.hats_primary_table_url}}/skymap.{{alt_order}}.fits) — Same, but for order {{alt_order}}
+  - [`skymap.{{alt_order}}.fits`]({{uris["primary"]["uri"]}}/skymap.{{alt_order}}.fits) — Same, but for order {{alt_order}}
   {%- endfor %}
   {%- endif %}
-{%- if col_props.default_margin %}
-- [`{{col_props.default_margin}}/`](./{{col_props.hats_primary_table_url}}/{{col_props.default_margin}}/) — margin catalog to ensure data completeness in cross-matching, margin threshold is {{ '%.1f' % margin_thresholds[col_props.default_margin]}} arcseconds
-  - ... margin catalog files and directories ...
-{%- endif %}
-{%- for margin in (col_props.all_margins or []) if margin != col_props.default_margin %}
-- [`{{margin}}/`](./{{margin}}/) — margin catalog to ensure data completeness in cross-matching, margin threshold is {{ '%.1f' % margin_thresholds[margin]}} arcseconds
+{%- for margin in uris["margins"] %}
+- [`{{margin["name"]}}/`]({{margin["uri"]}}) — {% if loop.first and col_props.default_margin %}default {% endif %}margin catalog to ensure data completeness in cross-matching, the margin threshold is {{ '%.1f' % margin_thresholds[margin["name"]]}} arcseconds
   - ... margin catalog files and directories ...
 {%- endfor %}
-{%- if col_props.default_index %}{%- set dir = col_props.all_indexes[col_props.default_index] %}
-- [`{{dir}}/`](./{{dir}}/) — default secondary index catalog for fast queries over column `{{col_props.default_index}}`
-  - ... index catalog files and directories ...
-{%- endif %}
-{%- for column, dir in (col_props.all_indexes or {}).items() if column != col_props.default_index %}
-- [`{{dir}}/`](./{{dir}}/) — secondary index catalog for fast queries over column `column`
+{%- for index in uris["indexes"] %}
+- [`{{index["name"]}}/`]({{index["uri"]}}) — {% if loop.first and col_props.default_index %}default {% endif %}secondary index catalog for fast queries over column `{{index["column"]}}`
   - ... index catalog files and directories ...
 {%- endfor %}
 
@@ -85,7 +78,7 @@ The main HATS catalog contains the following columns:
 | **Name** | {% for col in column_table.column %} **`{{col}}`** |{% endfor %}
 | --- | {% for _ in column_table.column %} --- |{% endfor %}
 | **Data Type** | {% for value in column_table.dtype %} `{{value}}` |{% endfor %}
-{% if has_default_columns -%}
+{%- if has_default_columns %}
 | **Default?** | {%- for value in column_table.default %} {{ "Yes" if value else "No" }} |{%- endfor %}
 {%- endif %}
 {% if has_nested_columns -%}
@@ -94,7 +87,7 @@ The main HATS catalog contains the following columns:
 {%if has_default_columns %}
 "Default" indicates whether the column is included when loading the catalog with `lsdb.open_catalog()`
 without specifying any columns to load.
-The list of default columns is available in the [`hats.properties`](./{{col_props.hats_primary_table_url}}/hats.properties) file.
+The list of default columns is available in the [`hats.properties`]({{uris["primary"]["uri"]}}/hats.properties) file.
 {% endif %}
 {%if has_nested_columns %}
 "Nested" indicates whether the column is stored as a nested field inside another "struct" column.

--- a/src/hats/io/validation.py
+++ b/src/hats/io/validation.py
@@ -71,7 +71,7 @@ def is_valid_catalog(
         else:
             warnings.warn(msg)
 
-    (is_valid, _) = _is_valid_catalog_strict(pointer, handle_error, verbose)
+    is_valid, _ = _is_valid_catalog_strict(pointer, handle_error, verbose)
     return is_valid
 
 
@@ -134,7 +134,7 @@ def is_valid_collection(
     is_valid = True
 
     collection_properties = CollectionProperties.read_from_dir(pointer)
-    (subcatalog_valid, sub_catalog) = _is_valid_catalog_strict(
+    subcatalog_valid, sub_catalog = _is_valid_catalog_strict(
         pointer / collection_properties.hats_primary_table_url,
         handle_error,
         verbose,
@@ -150,7 +150,7 @@ def is_valid_collection(
 
     if collection_properties.all_margins:
         for margin in collection_properties.all_margins:
-            (subcatalog_valid, sub_catalog) = _is_valid_catalog_strict(
+            subcatalog_valid, sub_catalog = _is_valid_catalog_strict(
                 pointer / margin,
                 handle_error,
                 verbose,
@@ -166,7 +166,7 @@ def is_valid_collection(
 
     if collection_properties.all_indexes:
         for index_field, index_dir in collection_properties.all_indexes.items():
-            (subcatalog_valid, sub_catalog) = _is_valid_catalog_strict(
+            subcatalog_valid, sub_catalog = _is_valid_catalog_strict(
                 pointer / index_dir, handle_error, verbose
             )
             is_valid &= subcatalog_valid

--- a/src/hats/pixel_tree/pixel_tree.py
+++ b/src/hats/pixel_tree/pixel_tree.py
@@ -66,7 +66,7 @@ class PixelTree:
         bool
             True if the tree contains the pixel, False if not
         """
-        (order, pixel) = get_healpix_tuple(pixel)
+        order, pixel = get_healpix_tuple(pixel)
         if order > self.tree_order:
             return False
         d_order = self.tree_order - order

--- a/tests/hats/catalog/dataset/test_collection_properties.py
+++ b/tests/hats/catalog/dataset/test_collection_properties.py
@@ -32,12 +32,9 @@ def test_collection_properties_string():
     )
 
     ## str representation should not include additional properties.
-    assert (
-        str(expected_properties)
-        == """  name small_sky_01
+    assert str(expected_properties) == """  name small_sky_01
   hats_primary_table_url small_sky_order1
 """
-    )
 
 
 def test_read_collection_list_parse(tmp_path):

--- a/tests/hats/io/file_io/test_file_io.py
+++ b/tests/hats/io/file_io/test_file_io.py
@@ -134,16 +134,16 @@ def test_read_parquet_data(tmp_path):
 
 
 def test_read_parquet_dataset(small_sky_dir, small_sky_order1_dir):
-    (paths, ds) = read_parquet_dataset(small_sky_dir / "dataset" / "Norder=0")
+    paths, ds = read_parquet_dataset(small_sky_dir / "dataset" / "Norder=0")
 
     assert ds.count_rows() == 131
 
-    (paths, ds) = read_parquet_dataset([small_sky_dir / "dataset" / "Norder=0" / "Dir=0" / "Npix=11.parquet"])
+    paths, ds = read_parquet_dataset([small_sky_dir / "dataset" / "Norder=0" / "Dir=0" / "Npix=11.parquet"])
 
     assert ds.count_rows() == 131
     assert len(paths) == 1
 
-    (paths, ds) = read_parquet_dataset(
+    paths, ds = read_parquet_dataset(
         [
             small_sky_order1_dir / "dataset" / "Norder=1" / "Dir=0" / "Npix=44.parquet",
             small_sky_order1_dir / "dataset" / "Norder=1" / "Dir=0" / "Npix=45.parquet",

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -131,6 +131,7 @@ def test_generate_markdown_collection_summary_basic(small_sky_collection_dir):
         collection=collection,
         name="Test Title",
         description="Test Description",
+        uri=None,
         huggingface_metadata=False,
     )
 
@@ -147,6 +148,7 @@ def test_generate_markdown_collection_summary_with_huggingface(small_sky_collect
         collection=collection,
         name="Test Title",
         description="Test Description",
+        uri=None,
         huggingface_metadata=True,
     )
 

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -3,10 +3,19 @@
 import re
 import shutil
 
+import nested_pandas as npd
+import pandas as pd
+import pyarrow as pa
 import pytest
 import yaml
 
-from hats.io.summary_file import generate_markdown_collection_summary, write_collection_summary_file
+from hats.io.summary_file import (
+    _gen_md_column_table,
+    _gen_md_metadata_table,
+    default_md_template,
+    generate_markdown_collection_summary,
+    write_collection_summary_file,
+)
 from hats.loaders import read_hats
 
 
@@ -43,8 +52,8 @@ def test_write_collection_summary_file_markdown(tmp_path, small_sky_collection_d
 
     # Check that the file has basic content
     content = output_path.read_text()
-    assert "small_sky_o1_collection HATS catalog" in content
-    assert "This is the `small_sky_o1_collection` HATS collection." in content
+    assert "small_sky_o1_collection HATS Catalog" in content
+    assert "This is the collection of HATS catalogs representing small_sky_o1_collection" in content
 
 
 def test_write_collection_summary_file_custom_filename(tmp_path, small_sky_collection_dir):
@@ -63,23 +72,23 @@ def test_write_collection_summary_file_custom_filename(tmp_path, small_sky_colle
     assert output_path.parent == collection_base_dir
 
 
-def test_write_collection_summary_file_custom_title_description(tmp_path, small_sky_collection_dir):
+def test_write_collection_summary_file_custom_name_description(tmp_path, small_sky_collection_dir):
     """Test writing a summary file with custom title and description"""
     collection_base_dir = tmp_path / "collection"
     shutil.copytree(small_sky_collection_dir, collection_base_dir)
 
-    custom_title = "My Custom Title"
+    custom_name = "My Custom Title"
     custom_description = "This is a custom description for the catalog."
 
     output_path = write_collection_summary_file(
         collection_base_dir,
         fmt="markdown",
-        title=custom_title,
+        name=custom_name,
         description=custom_description,
     )
 
     content = output_path.read_text()
-    assert custom_title in content
+    assert custom_name in content
     assert custom_description in content
 
 
@@ -102,18 +111,6 @@ def test_write_collection_summary_file_with_huggingface_metadata(tmp_path, small
     assert "astronomy" in content
 
 
-def test_write_collection_summary_file_invalid_format(tmp_path, small_sky_collection_dir):
-    """Test that invalid format raises an error"""
-    collection_base_dir = tmp_path / "collection"
-    shutil.copytree(small_sky_collection_dir, collection_base_dir)
-
-    with pytest.raises(ValueError, match="Unsupported format"):
-        write_collection_summary_file(
-            collection_base_dir,
-            fmt="xml",  # Not supported
-        )
-
-
 def test_write_collection_summary_file_unsupported_fits_format(tmp_path, small_sky_collection_dir):
     """Test that fits format raises an error for unsupported format"""
     collection_base_dir = tmp_path / "collection"
@@ -132,14 +129,14 @@ def test_generate_markdown_collection_summary_basic(small_sky_collection_dir):
 
     content = generate_markdown_collection_summary(
         collection=collection,
-        title="Test Title",
+        name="Test Title",
         description="Test Description",
         huggingface_metadata=False,
     )
 
     assert "# Test Title" in content
     assert "Test Description" in content
-    assert "---" not in content  # No YAML frontmatter
+    assert "config_name" not in content  # No YAML frontmatter
 
 
 def test_generate_markdown_collection_summary_with_huggingface(small_sky_collection_dir):
@@ -148,7 +145,7 @@ def test_generate_markdown_collection_summary_with_huggingface(small_sky_collect
 
     content = generate_markdown_collection_summary(
         collection=collection,
-        title="Test Title",
+        name="Test Title",
         description="Test Description",
         huggingface_metadata=True,
     )
@@ -327,3 +324,130 @@ def test_load_hats_collection_with_huggingface_datasets(tmp_path, small_sky_coll
     # Load index catalog and verify exact row count
     index_catalog = read_hats(collection_base_dir / index_dir)
     assert len(dataset_index["train"]) == index_catalog.catalog_info.total_rows
+
+
+def test_write_collection_summary_file_custom_output_dir(tmp_path, small_sky_collection_dir):
+    """Test writing a summary file to a custom output directory"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    output_dir = tmp_path / "custom_output"
+
+    output_path = write_collection_summary_file(
+        collection_base_dir,
+        fmt="markdown",
+        output_dir=output_dir,
+    )
+
+    assert output_path.exists()
+    assert output_path.parent == output_dir
+    assert output_path.name == "README.md"
+
+
+def test_write_collection_summary_file_custom_uri(tmp_path, small_sky_collection_dir):
+    """Test writing a summary file with a custom URI"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    custom_uri = "s3://my-bucket/my-catalog"
+
+    output_path = write_collection_summary_file(
+        collection_base_dir,
+        fmt="markdown",
+        uri=custom_uri,
+    )
+
+    content = output_path.read_text()
+    assert custom_uri in content
+
+
+def test_write_collection_summary_file_custom_jinja2_template(tmp_path, small_sky_collection_dir):
+    """Test writing a summary file with a custom jinja2 template"""
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    custom_name = "Test Catalog Name"
+    custom_description = "Test catalog description."
+    custom_template = "Name: {{ name }}\nDescription: {{ description }}"
+
+    output_path = write_collection_summary_file(
+        collection_base_dir,
+        fmt="markdown",
+        name=custom_name,
+        description=custom_description,
+        jinja2_template=custom_template,
+    )
+
+    content = output_path.read_text()
+    assert content == "Name: Test Catalog Name\nDescription: Test catalog description."
+
+
+def test_default_md_template():
+    """Test that default_md_template returns a valid jinja2 template string"""
+    template = default_md_template()
+    assert isinstance(template, str)
+    assert len(template) > 0
+
+
+def test_gen_md_metadata_table(small_sky_collection_dir):
+    """Test metadata table generation with proper formatting"""
+    collection = read_hats(small_sky_collection_dir)
+    catalog = collection.main_catalog
+
+    # Test with total_columns=6 (includes healpix column)
+    metadata_table = _gen_md_metadata_table(catalog, total_columns=6)
+
+    # Check exact row count
+    assert metadata_table["Number of rows"] == "131"
+
+    # Check exact partition count
+    assert metadata_table["Number of partitions"] == "4"
+
+    # Column count should exclude healpix column (6 - 1 = 5)
+    assert metadata_table["Number of columns"] == "5"
+
+
+def test_gen_md_column_table_nested_columns():
+    """Test column table generation with nested and regular columns"""
+    # Create a custom nested frame with regular and nested columns
+    nf = npd.NestedFrame(
+        {
+            "id": pd.array([1, 2], dtype=pd.ArrowDtype(pa.int64())),
+            "ra": pd.array([1.0, 2.0], dtype=pd.ArrowDtype(pa.float64())),
+            "dec": pd.array([3.0, 4.0], dtype=pd.ArrowDtype(pa.float64())),
+        }
+    )
+
+    # Add a nested column with subcolumns
+    nested = npd.NestedFrame(
+        {
+            "flux": pd.array([1.0, 2.0], dtype=pd.ArrowDtype(pa.float32())),
+            "mag": pd.array([20.0, 21.0], dtype=pd.ArrowDtype(pa.float32())),
+        }
+    )
+    nf = nf.join_nested(nested, "photometry")
+
+    default_columns = ["id", "ra", "photometry.flux"]
+
+    column_table = _gen_md_column_table(nf, default_columns)
+
+    # Should have 5 rows: id, ra, dec, photometry.flux, photometry.mag
+    assert len(column_table) == 5
+
+    # Verify exact structure
+    expected = pd.DataFrame(
+        {
+            "column": ["id", "ra", "dec", "photometry.flux", "photometry.mag"],
+            "dtype": [
+                "int64",
+                "double",
+                "double",
+                "list[float]",
+                "list[float]",
+            ],
+            "default": [True, True, False, True, False],
+            "nested_into": [None, None, None, "photometry", "photometry"],
+        }
+    )
+
+    pd.testing.assert_frame_equal(column_table.reset_index(drop=True), expected)


### PR DESCRIPTION
Another stage of #615

- Extend generated README.md. [See examples here](https://gist.github.com/hombit/36bed42edfb0cb9db9645e56e9e00447) (test catalog, DP1, ZTF).
- Introduce `human_readable` dependency, ~I added it before we've found that it is not in Conda, should I remove it?~ (on Conda now)
- Jinja2 template is moved to a new file.