### PR TITLE
Use Haversine formula in cone_filter (#624)

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -87,6 +87,13 @@ def time_small_cone_large_catalog():
 class ConeFilterSuite:
     """Benchmark the cone_filter angular separation computation."""
 
+    def __init__(self):
+        self.metadata = None
+        self.data_frame = None
+        self.ra = None
+        self.dec = None
+        self.radius_arcsec = None
+
     def setup(self):
         rng = np.random.default_rng(42)
         n = 100_000

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -91,7 +91,7 @@ class AngularSeparationSuite:
         rng = np.random.default_rng(42)
         n = 100_000
         ra = rng.uniform(0, 360, n)
-        dec = rng.uniform(-90, 90, n)
+        dec = np.degrees(np.arcsin(rng.uniform(-1, 1, n)))
         self.metadata = TableProperties(
             catalog_name="bench",
             catalog_type="object",
@@ -104,5 +104,5 @@ class AngularSeparationSuite:
         self.dec = 0.0
         self.radius_arcsec = 10.0 * 3600  # 10 degrees
 
-    def time_cone_filter(self):
+    def time_cone_filter_benchmark(self):
         cone_filter(self.data_frame, self.ra, self.dec, self.radius_arcsec, self.metadata)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -5,6 +5,7 @@ https://asv.readthedocs.io/en/stable/writing_benchmarks.html."""
 
 from pathlib import Path
 
+import nested_pandas as npd
 import numpy as np
 
 import hats.pixel_math as hist
@@ -14,6 +15,7 @@ from hats.catalog import Catalog, TableProperties
 from hats.pixel_math import HealpixPixel
 from hats.pixel_tree import align_trees
 from hats.pixel_tree.pixel_tree import PixelTree
+from hats.search.region_search import cone_filter
 
 BENCH_DATA_DIR = Path(__file__).parent / "data"
 
@@ -80,3 +82,27 @@ def time_small_cone_large_catalog():
     original_catalog = read_hats(BENCH_DATA_DIR / "large_catalog")
 
     original_catalog.filter_by_cone(315, -66.443, 1)
+
+
+class AngularSeparationSuite:
+    """Benchmark the cone_filter angular separation computation."""
+
+    def setup(self):
+        rng = np.random.default_rng(42)
+        n = 100_000
+        ra = rng.uniform(0, 360, n)
+        dec = rng.uniform(-90, 90, n)
+        self.metadata = TableProperties(
+            catalog_name="bench",
+            catalog_type="object",
+            total_rows=n,
+            ra_column="ra",
+            dec_column="dec",
+        )
+        self.data_frame = npd.NestedFrame({"ra": ra, "dec": dec})
+        self.ra = 180.0
+        self.dec = 0.0
+        self.radius_arcsec = 10.0 * 3600  # 10 degrees
+
+    def time_cone_filter(self):
+        cone_filter(self.data_frame, self.ra, self.dec, self.radius_arcsec, self.metadata)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -84,7 +84,7 @@ def time_small_cone_large_catalog():
     original_catalog.filter_by_cone(315, -66.443, 1)
 
 
-class AngularSeparationSuite:
+class ConeFilterSuite:
     """Benchmark the cone_filter angular separation computation."""
 
     def setup(self):

--- a/src/hats/search/region_search.py
+++ b/src/hats/search/region_search.py
@@ -93,10 +93,10 @@ def cone_filter(data_frame: npd.NestedFrame, ra, dec, radius_arcsec, metadata: T
     dec0 = np.radians(dec)
 
     cos_dec0 = np.cos(dec0)
-    a = (
-        np.square(np.sin((dec_rad - dec0) * 0.5))
-        + cos_dec0 * np.cos(dec_rad) * np.square(np.sin((ra_rad - ra0) * 0.5))
-    )
+    # Haversine formula
+    hav_dec = np.square(np.sin((dec_rad - dec0) * 0.5))
+    hav_ra = np.square(np.sin((ra_rad - ra0) * 0.5))
+    a = hav_dec + cos_dec0 * np.cos(dec_rad) * hav_ra
     radius_rad = np.radians(radius_arcsec / 3600)
     threshold = np.square(np.sin(radius_rad * 0.5))
     data_frame = data_frame[a <= threshold]

--- a/src/hats/search/region_search.py
+++ b/src/hats/search/region_search.py
@@ -92,12 +92,13 @@ def cone_filter(data_frame: npd.NestedFrame, ra, dec, radius_arcsec, metadata: T
     ra0 = np.radians(ra)
     dec0 = np.radians(dec)
 
-    d_ra = ra_rad - ra0
-    d_dec = dec_rad - dec0
-    a = np.sin(d_dec / 2) ** 2 + np.cos(dec_rad) * np.cos(dec0) * np.sin(d_ra / 2) ** 2
-    separation = 2 * np.arcsin(np.sqrt(np.clip(a, 0.0, 1.0)))
+    cos_dec0 = np.cos(dec0)
+    a = np.square(np.sin((dec_rad - dec0) * 0.5)) + cos_dec0 * np.cos(dec_rad) * np.square(
+        np.sin((ra_rad - ra0) * 0.5)
+    )
     radius_rad = np.radians(radius_arcsec / 3600)
-    data_frame = data_frame[separation <= radius_rad]
+    threshold = np.square(np.sin(radius_rad * 0.5))
+    data_frame = data_frame[a <= threshold]
     return data_frame
 
 

--- a/src/hats/search/region_search.py
+++ b/src/hats/search/region_search.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import nested_pandas as npd
 import numpy as np
-from astropy.coordinates import angular_separation
 
 import hats.pixel_math.healpix_shim as hp
 from hats.catalog import TableProperties
@@ -93,7 +92,10 @@ def cone_filter(data_frame: npd.NestedFrame, ra, dec, radius_arcsec, metadata: T
     ra0 = np.radians(ra)
     dec0 = np.radians(dec)
 
-    separation = angular_separation(ra_rad, dec_rad, ra0, dec0)
+    d_ra = ra_rad - ra0
+    d_dec = dec_rad - dec0
+    a = np.sin(d_dec / 2) ** 2 + np.cos(dec_rad) * np.cos(dec0) * np.sin(d_ra / 2) ** 2
+    separation = 2 * np.arcsin(np.sqrt(np.clip(a, 0.0, 1.0)))
     radius_rad = np.radians(radius_arcsec / 3600)
     data_frame = data_frame[separation <= radius_rad]
     return data_frame

--- a/src/hats/search/region_search.py
+++ b/src/hats/search/region_search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import nested_pandas as npd
 import numpy as np
+from astropy.coordinates import angular_separation
 
 import hats.pixel_math.healpix_shim as hp
 from hats.catalog import TableProperties
@@ -92,13 +93,9 @@ def cone_filter(data_frame: npd.NestedFrame, ra, dec, radius_arcsec, metadata: T
     ra0 = np.radians(ra)
     dec0 = np.radians(dec)
 
-    cos_angle = np.sin(dec_rad) * np.sin(dec0) + np.cos(dec_rad) * np.cos(dec0) * np.cos(ra_rad - ra0)
-
-    # Clamp to valid range to avoid numerical issues
-    cos_separation = np.clip(cos_angle, -1.0, 1.0)
-
-    cos_radius = np.cos(np.radians(radius_arcsec / 3600))
-    data_frame = data_frame[cos_separation >= cos_radius]
+    separation = angular_separation(ra_rad, dec_rad, ra0, dec0)
+    radius_rad = np.radians(radius_arcsec / 3600)
+    data_frame = data_frame[separation <= radius_rad]
     return data_frame
 
 

--- a/src/hats/search/region_search.py
+++ b/src/hats/search/region_search.py
@@ -93,8 +93,9 @@ def cone_filter(data_frame: npd.NestedFrame, ra, dec, radius_arcsec, metadata: T
     dec0 = np.radians(dec)
 
     cos_dec0 = np.cos(dec0)
-    a = np.square(np.sin((dec_rad - dec0) * 0.5)) + cos_dec0 * np.cos(dec_rad) * np.square(
-        np.sin((ra_rad - ra0) * 0.5)
+    a = (
+        np.square(np.sin((dec_rad - dec0) * 0.5))
+        + cos_dec0 * np.cos(dec_rad) * np.square(np.sin((ra_rad - ra0) * 0.5))
     )
     radius_rad = np.radians(radius_arcsec / 3600)
     threshold = np.square(np.sin(radius_rad * 0.5))


### PR DESCRIPTION
Replace manual spherical cosine formula with [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula), which has better numeric accuracy (see #624 and Eq. 3 from [this paper](http://www.ati.ac.cn/en/article/pdf/preview/2317.pdf)), converting all coordinates to radians and comparing the separation in radians. Add an ASV benchmark for the cone_filter angular separation computation.

I also tried astropy's `angular_separation` function, but it is ~2x slower (see history of the benchmark comment bellow).

https://claude.ai/code/session_01D2WEdPXU3F8cfdmewEYXX8