### PR TITLE
Re-add none check for file exists.

### DIFF
--- a/src/hats/io/file_io/file_io.py
+++ b/src/hats/io/file_io/file_io.py
@@ -211,6 +211,8 @@ def read_parquet_metadata(file_pointer: str | Path | UPath, **kwargs) -> pq.File
         parqeut file metadata (includes schema)
     """
     file_pointer = get_upath(file_pointer)
+    if file_pointer is None:
+        raise FileNotFoundError("Parquet file does not exist")
     if _parquet_precache_all_bytes(file_pointer):  # pragma: no cover
         return pq.read_metadata(BytesIO(file_pointer.read_bytes()), **kwargs)
 


### PR DESCRIPTION
## Change Description

Removed by https://github.com/astronomy-commons/hats/pull/639

Still not checking `.exists()`, but we can at least not allow a None through.

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
