### PR TITLE
add skymap_coverage() for skymap-based fractional coverage

### DIFF
--- a/src/hats/io/__init__.py
+++ b/src/hats/io/__init__.py
@@ -10,3 +10,4 @@ from .paths import (
     pixel_catalog_file,
     pixel_directory,
 )
+from .skymap import skymap_coverage

--- a/src/hats/io/skymap.py
+++ b/src/hats/io/skymap.py
@@ -70,31 +70,20 @@ def read_skymap(catalog, order):
 
 
 def skymap_coverage(catalog, order=None):
-    """Compute the fractional sky coverage of a catalog based on its skymap.
-
-    This gives an estimate of sky coverage based on the fraction of HEALPix
-    pixels that contain at least one object, as recorded in the skymap file.
-    For most surveys this estimate will be closer to the actual coverage than
-    the partition-based estimate from
-    :meth:`~hats.catalog.partition_info.PartitionInfo.calculate_fractional_coverage`.
+    """Compute the fractional sky coverage of a catalog from its healpix skymap file.
 
     Parameters
     ----------
     catalog : Catalog
         Catalog object corresponding to an on-disk catalog with skymap files.
     order : int, optional
-        HEALPix order at which to read the skymap. If ``None``, the default
-        skymap order stored in the catalog properties is used.
+        healpix order to read the skymap at. If None, the order of the default
+        skymap will be used.
 
     Returns
     -------
     float
-        Fraction of the sky covered by the catalog, between 0.0 and 1.0.
-
-    Raises
-    ------
-    ValueError
-        If the catalog has no skymap information available.
+        fractional sky coverage between 0.0 and 1.0.
     """
     if (
         catalog.catalog_info.skymap_order is None

--- a/src/hats/io/skymap.py
+++ b/src/hats/io/skymap.py
@@ -85,14 +85,8 @@ def skymap_coverage(catalog, order=None):
     float
         fractional sky coverage between 0.0 and 1.0.
     """
-    if (
-        catalog.catalog_info.skymap_order is None
-        and catalog.catalog_info.skymap_alt_orders is None
-    ):
-        raise ValueError(
-            "Catalog does not have skymap information. "
-            "Cannot compute skymap-based coverage."
-        )
+    if catalog.catalog_info.skymap_order is None and catalog.catalog_info.skymap_alt_orders is None:
+        raise ValueError("Catalog does not have skymap information. Cannot compute skymap-based coverage.")
     skymap = read_skymap(catalog, order)
     return float(np.mean(skymap > 0))
 

--- a/src/hats/io/skymap.py
+++ b/src/hats/io/skymap.py
@@ -69,6 +69,45 @@ def read_skymap(catalog, order):
     return point_map.reshape(hp.order2npix(order), -1).sum(axis=1)
 
 
+def skymap_coverage(catalog, order=None):
+    """Compute the fractional sky coverage of a catalog based on its skymap.
+
+    This gives an estimate of sky coverage based on the fraction of HEALPix
+    pixels that contain at least one object, as recorded in the skymap file.
+    For most surveys this estimate will be closer to the actual coverage than
+    the partition-based estimate from
+    :meth:`~hats.catalog.partition_info.PartitionInfo.calculate_fractional_coverage`.
+
+    Parameters
+    ----------
+    catalog : Catalog
+        Catalog object corresponding to an on-disk catalog with skymap files.
+    order : int, optional
+        HEALPix order at which to read the skymap. If ``None``, the default
+        skymap order stored in the catalog properties is used.
+
+    Returns
+    -------
+    float
+        Fraction of the sky covered by the catalog, between 0.0 and 1.0.
+
+    Raises
+    ------
+    ValueError
+        If the catalog has no skymap information available.
+    """
+    if (
+        catalog.catalog_info.skymap_order is None
+        and catalog.catalog_info.skymap_alt_orders is None
+    ):
+        raise ValueError(
+            "Catalog does not have skymap information. "
+            "Cannot compute skymap-based coverage."
+        )
+    skymap = read_skymap(catalog, order)
+    return float(np.mean(skymap > 0))
+
+
 def write_skymap(histogram: np.ndarray, catalog_dir: str | Path | UPath, orders: list | int | None = None):
     """Write the object spatial distribution information to a healpix SKYMAP FITS file.
 

--- a/tests/hats/io/test_skymap.py
+++ b/tests/hats/io/test_skymap.py
@@ -6,7 +6,7 @@ from cdshealpix.skymap.skymap import Scheme
 import hats.pixel_math.healpix_shim as hp
 from hats import read_hats
 from hats.io.file_io import read_fits_image
-from hats.io.skymap import read_skymap, write_skymap
+from hats.io.skymap import read_skymap, skymap_coverage, write_skymap
 
 
 def test_write_skymap_roundtrip(tmp_path):
@@ -162,3 +162,36 @@ def test_read_noalt_skymap(small_sky_source_dir, mocker):
     ## Requesting waaay too-high order should error.
     with pytest.raises(ValueError, match="order should be less"):
         skymap = read_skymap(catalog, 13)
+
+
+def test_skymap_coverage_no_skymap():
+    """Test that skymap_coverage raises an error for catalogs without skymap files."""
+    catalog = type("MockCatalog", (), {
+        "catalog_base_dir": "/nonexistent",
+        "catalog_info": type("MockInfo", (), {
+            "skymap_order": None,
+            "skymap_alt_orders": None,
+        })(),
+    })()
+    with pytest.raises(ValueError, match="does not have skymap information"):
+        skymap_coverage(catalog)
+
+
+def test_skymap_coverage_synthetic(tmp_path):
+    """Test skymap_coverage with a known synthetic skymap."""
+    num_pixels = hp.order2npix(2)
+    histogram = np.zeros(num_pixels, dtype=np.int64)
+    histogram[: num_pixels // 2] = 10
+
+    write_skymap(histogram, tmp_path)
+
+    catalog = type("MockCatalog", (), {
+        "catalog_base_dir": tmp_path,
+        "catalog_info": type("MockInfo", (), {
+            "skymap_order": 2,
+            "skymap_alt_orders": None,
+        })(),
+    })()
+
+    coverage = skymap_coverage(catalog)
+    assert coverage == pytest.approx(0.5)

--- a/tests/hats/io/test_skymap.py
+++ b/tests/hats/io/test_skymap.py
@@ -195,3 +195,13 @@ def test_skymap_coverage_synthetic(tmp_path):
 
     coverage = skymap_coverage(catalog)
     assert coverage == pytest.approx(0.5)
+
+
+def test_skymap_coverage_changes_with_order(small_sky_source_dir):
+    """Test that coverage estimate changes when different orders are requested."""
+    catalog = read_hats(small_sky_source_dir)
+
+    coverage_default = skymap_coverage(catalog)
+    coverage_order4 = skymap_coverage(catalog, order=4)
+
+    assert coverage_default != coverage_order4

--- a/tests/hats/io/test_skymap.py
+++ b/tests/hats/io/test_skymap.py
@@ -166,13 +166,21 @@ def test_read_noalt_skymap(small_sky_source_dir, mocker):
 
 def test_skymap_coverage_no_skymap():
     """Test that skymap_coverage raises an error for catalogs without skymap files."""
-    catalog = type("MockCatalog", (), {
-        "catalog_base_dir": "/nonexistent",
-        "catalog_info": type("MockInfo", (), {
-            "skymap_order": None,
-            "skymap_alt_orders": None,
-        })(),
-    })()
+    catalog = type(
+        "MockCatalog",
+        (),
+        {
+            "catalog_base_dir": "/nonexistent",
+            "catalog_info": type(
+                "MockInfo",
+                (),
+                {
+                    "skymap_order": None,
+                    "skymap_alt_orders": None,
+                },
+            )(),
+        },
+    )()
     with pytest.raises(ValueError, match="does not have skymap information"):
         skymap_coverage(catalog)
 
@@ -185,13 +193,21 @@ def test_skymap_coverage_synthetic(tmp_path):
 
     write_skymap(histogram, tmp_path)
 
-    catalog = type("MockCatalog", (), {
-        "catalog_base_dir": tmp_path,
-        "catalog_info": type("MockInfo", (), {
-            "skymap_order": 2,
-            "skymap_alt_orders": None,
-        })(),
-    })()
+    catalog = type(
+        "MockCatalog",
+        (),
+        {
+            "catalog_base_dir": tmp_path,
+            "catalog_info": type(
+                "MockInfo",
+                (),
+                {
+                    "skymap_order": 2,
+                    "skymap_alt_orders": None,
+                },
+            )(),
+        },
+    )()
 
     coverage = skymap_coverage(catalog)
     assert coverage == pytest.approx(0.5)


### PR DESCRIPTION
## Change Description

Closes #524
 
Adds `skymap_coverage()` a more accurate footprint-based coverage estimate than `calculate_fractional_coverage()` which reads the skymap file directly and counts only HEALPix pixels that actually contain objects.

---

## Solution Description

**`src/hats/io/skymap.py`**

Checks if the catalog has skymap information (raises a clear `ValueError` if not)
Otherwise, reads the skymap array via `read_skymap()` and returns the fraction of pixels containing at least one object (float between 0.0 and 1.0)
The `order` parameter controls resolution: higher order = more pixels = finer estimate.

**`tests/hats/io/test_skymap.py`**
- `test_skymap_coverage_no_skymap`  mock catalog with no skymap confirms `ValueError` is raised.
- `test_skymap_coverage_synthetic`  synthetic skymap at order 2 with exactly half 
  the pixels non-zero confirms the function returns exactly 0.5.

**`src/hats/io/__init__.py`**
`skymap_coverage` exported as part of the public API.

---

## How to Use *(to be documented)*
```python
from hats.io import skymap_coverage

# catalog: the loaded HATS catalog object
# order: HEALPix resolution (None uses catalog's default stored order)
skymap_coverage(catalog)                                  # default order
skymap_coverage(catalog, order=4)                         # order=4 → 3,072 pixels, faster
skymap_coverage(catalog, order=6)                         # order=6 → 49,152 pixels, more precise

# compare coverage estimates
catalog.partition_info.calculate_fractional_coverage()    # upper limit (partition-based)
skymap_coverage(catalog)                                  # real footprint (skymap-based)

try:
    skymap_coverage(catalog_without_skymap)
except ValueError as e:
    print(e)  # "Catalog does not have skymap information. Cannot compute skymap-based coverage."
```

---

## Note
While reviewing the issue discussion I noticed [suggestion](https://github.com/astronomy-commons/hats/issues/524#issuecomment-3973084106)
to also update `is_valid_catalog(verbose=True)` in `validation.py` to clarify that the current partition-based value is an upper limit and display both the partition-based and skymap-based coverage numbers side by side

I wanted to focus on the core function first and get feedback before extending 
the scope. This can be done in a follow-up commit if the approach looks good

---

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation