### PR TITLE
Handle remote file systems when reading/writing histograms.

### DIFF
--- a/src/hats/pixel_math/sparse_histogram.py
+++ b/src/hats/pixel_math/sparse_histogram.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 import hats.pixel_math.healpix_shim as hp
+from hats.io import file_io
 
 
 class SparseHistogram:
@@ -48,7 +49,9 @@ class SparseHistogram:
         file_name : path-like
             intended file to save to
         """
-        np.savez(file_name, indexes=self.indexes, counts=self.counts, order=self.order)
+        file_name = file_io.get_upath(file_name)
+        with file_name.open("wb") as file_handle:
+            np.savez(file_handle, indexes=self.indexes, counts=self.counts, order=self.order)
 
     def to_dense_file(self, file_name):
         """Persist the DENSE array to disk as a numpy array.
@@ -58,7 +61,8 @@ class SparseHistogram:
         file_name : path-like
             intended file to save to
         """
-        with open(file_name, "wb+") as file_handle:
+        file_name = file_io.get_upath(file_name)
+        with file_name.open("wb") as file_handle:
             file_handle.write(self.to_array().data)
 
     @classmethod
@@ -75,8 +79,10 @@ class SparseHistogram:
         SparseHistogram
             new sparse histogram
         """
-        npzfile = np.load(file_name)
-        return cls(npzfile["indexes"], npzfile["counts"], npzfile["order"])
+        file_name = file_io.get_upath(file_name)
+        with file_name.open("rb") as file_handle:
+            npzfile = np.load(file_handle)
+            return cls(npzfile["indexes"], npzfile["counts"], npzfile["order"])
 
     def __eq__(self, value):
         if not isinstance(value, SparseHistogram):


### PR DESCRIPTION
## Change Description

Addresses hats-cloudtests failures, by passing numpy file operations an already-opened file handle, since it doesn't know how to deal with remote file system instances on its own.

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
