### PR TITLE
Add a show_versions method

### DIFF
--- a/src/hats/__init__.py
+++ b/src/hats/__init__.py
@@ -2,5 +2,6 @@
 
 from . import catalog, inspection, io, pixel_math, search
 from ._version import __version__
+from .io.show_versions import show_versions
 from .loaders import read_hats
 from .pixel_math import HealpixPixel

--- a/src/hats/io/show_versions.py
+++ b/src/hats/io/show_versions.py
@@ -1,0 +1,92 @@
+import importlib
+import os
+import platform
+import struct
+import subprocess
+import sys
+
+
+def _get_sys_info() -> dict[str, str]:
+    uname_result = platform.uname()
+    return {
+        "python": platform.python_version(),
+        "python-bits": str(struct.calcsize("P") * 8),
+        "OS": uname_result.system,
+        "OS-release": uname_result.release,
+        "Version": uname_result.version,
+        "machine": uname_result.machine,
+        "processor": uname_result.processor,
+        "byteorder": sys.byteorder,
+        "LC_ALL": os.environ.get("LC_ALL") or "",
+        "LANG": os.environ.get("LANG") or "",
+    }
+
+
+def _get_dependency_info(deps) -> dict[str, str]:
+    if deps is None or len(deps) == 0:
+        deps = [
+            "hats",
+            "nested-pandas",
+            "pandas",
+            "numpy",
+            "pyarrow",
+            "fsspec",
+        ]
+
+    result: dict[str, str] = {}
+    for modname in deps:
+        try:
+            result[modname] = importlib.metadata.version(modname)
+        except Exception:  # pylint: disable=broad-exception-caught # pragma: no cover
+            result[modname] = "N/A"
+    return result
+
+
+def _get_package_info(package_name):
+    """For the hats project (or other primary dependency),
+    try to find if we're currently in a branch, and name it."""
+    installed_version = None
+    try:
+        installed_version = importlib.metadata.version(package_name)
+    except Exception:  # pylint: disable=broad-exception-caught # pragma: no cover
+        pass
+    try:
+        # Runs the git command to return the current branch name
+        branch = (
+            subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], stderr=subprocess.STDOUT)
+            .decode("utf-8")
+            .strip()
+        )
+        if installed_version is None:
+            return branch
+        return f"{installed_version} ({branch})"
+    except subprocess.CalledProcessError:
+        return "N/A"
+
+
+def print_versions(package_name, extra_deps):
+    """Print runtime versions and system info, useful for bug reports."""
+    sys_info = _get_sys_info()
+    deps = _get_dependency_info(extra_deps)
+
+    maxlen = max(len(x) for x in deps) + 1
+    print("\n--------      SYSTEM INFO      --------")
+    for k, v in sys_info.items():
+        print(f"{k:<{maxlen}}: {v}")
+    print("--------   INSTALLED VERSIONS   --------")
+    print(f"{package_name:<{maxlen}}: {_get_package_info(package_name=package_name)}")
+    for k, v in deps.items():
+        print(f"{k:<{maxlen}}: {v}")
+
+
+def show_versions():
+    """Print runtime versions and system info, useful for bug reports."""
+    print_versions("hats",
+        [
+            "nested-pandas",
+            "pandas",
+            "numpy",
+            "pyarrow",
+            "fsspec",
+        ]
+    )

--- a/src/hats/io/show_versions.py
+++ b/src/hats/io/show_versions.py
@@ -81,12 +81,13 @@ def print_versions(package_name, extra_deps):
 
 def show_versions():
     """Print runtime versions and system info, useful for bug reports."""
-    print_versions("hats",
+    print_versions(
+        "hats",
         [
             "nested-pandas",
             "pandas",
             "numpy",
             "pyarrow",
             "fsspec",
-        ]
+        ],
     )

--- a/tests/hats/io/test_show_versions.py
+++ b/tests/hats/io/test_show_versions.py
@@ -1,0 +1,11 @@
+import hats
+
+
+def test_show_versions(capsys):
+    hats.show_versions()
+    captured = capsys.readouterr().out
+    assert captured.startswith("\n--------      SYSTEM INFO      --------")
+    assert "hats" in captured
+    assert "nested-pandas" in captured
+    assert "pyarrow" in captured
+    assert "fsspec" in captured


### PR DESCRIPTION
## Change Description

I really like the `lsdb.show_versions` method, and would be nice to have it here as well (and I could have sworn I'd opened a ticket to that effect).

NB:
- This method can be re-used in LSDB and hats-import pretty easily.
- this will also find the branch (if you're on a branch) and print that out, since I wanted that info too.

Example invocation:

```
>>> import hats
>>> hats.show_versions()

--------      SYSTEM INFO      --------
python        : 3.11.11
python-bits   : 64
OS            : Linux
OS-release    : 6.5.0-1025-oem
Version       : #26-Ubuntu SMP PREEMPT_DYNAMIC Tue Jun 18 12:35:22 UTC 2024
machine       : x86_64
processor     : x86_64
byteorder     : little
LC_ALL        : 
LANG          : en_US.UTF-8
--------   INSTALLED VERSIONS   --------
hats          : 0.9.1.dev19+g729a98acb (delucchi/show_versions)
nested-pandas : 0.6.10
pandas        : 2.3.3
numpy         : 2.4.5
pyarrow       : 24.0.0
fsspec        : 2026.4.0
```
