### PR TITLE
Drop filters query parameter for Vizcat

### DIFF
--- a/src/hats/io/file_io/file_pointer.py
+++ b/src/hats/io/file_io/file_pointer.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from upath import UPath
 
 BLOCK_SIZE = 32 * 1024
+_VIZCAT_HOST = "vizcat.cds.unistra.fr"
 
 
 def get_upath(path: str | Path | UPath) -> UPath:
@@ -55,10 +56,35 @@ def get_upath_for_protocol(path: str | Path) -> UPath:
         }
 
         parts = urlparse(path)
-        if parts.netloc == "vizcat.cds.unistra.fr":
+        if parts.netloc == _VIZCAT_HOST:
             kwargs["cache_options"] = {"parquet_precache_all_bytes": True}
         upath = UPath(path, **kwargs)
     return upath
+
+
+def filter_query_params_for_url(url: str, query_params: dict) -> dict:
+    """Return a copy of ``query_params`` with any keys unsupported by the target
+    host removed.
+
+    Currently the only special case is VizCaT (``vizcat.cds.unistra.fr``), which
+    does not support server-side ``filters``.
+
+    Parameters
+    ----------
+    url : str
+        Full URL of the catalog resource (used only to inspect the host).
+    query_params : dict
+        Query parameters dict as produced by
+        :func:`~hats.io.paths.dict_to_query_urlparams`.
+
+    Returns
+    -------
+    dict
+        Filtered copy of ``query_params``.
+    """
+    if urlparse(url).netloc == _VIZCAT_HOST:
+        return {k: v for k, v in query_params.items() if k != "filters"}
+    return query_params
 
 
 def directory_has_contents(pointer: str | Path | UPath) -> bool:

--- a/src/hats/io/paths.py
+++ b/src/hats/io/paths.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 from fsspec.implementations.http import HTTPFileSystem
 from upath import UPath
 
-from hats.io.file_io.file_pointer import get_upath
+from hats.io.file_io.file_pointer import filter_query_params_for_url, get_upath
 from hats.pixel_math.healpix_pixel import INVALID_PIXEL, HealpixPixel
 
 PARTITION_ORDER = "Norder"
@@ -207,6 +207,7 @@ def pixel_catalog_file(
 
     url_params = ""
     if isinstance(catalog_base_dir.fs, HTTPFileSystem) and query_params:
+        query_params = filter_query_params_for_url(str(catalog_base_dir), query_params)
         url_params = dict_to_query_urlparams(query_params)
 
     return (

--- a/tests/hats/io/test_paths.py
+++ b/tests/hats/io/test_paths.py
@@ -53,6 +53,18 @@ def test_pixel_catalog_file_w_query_params():
     assert expected == str(result)
 
 
+def test_pixel_catalog_file_vizcat_drops_filters():
+    """Filters are excluded from the query string for vizcat URLs."""
+    query_params = {"columns": ["ID", "RA", "DEC"], "filters": ["r_auto<13"]}
+    result = paths.pixel_catalog_file(
+        "https://vizcat.cds.unistra.fr/hats/gaia_dr3",
+        HealpixPixel(0, 5),
+        query_params=query_params,
+    )
+    assert "columns=" in str(result)
+    assert "filters=" not in str(result)
+
+
 def test_pixel_catalog_file_nonint():
     """Simple case with non-integer inputs"""
     with pytest.raises(AttributeError):


### PR DESCRIPTION
Vizier's HATS-on-the-fly (Vizcat) service uses a different query parameter format for `filters`. Since we don't implement it yet (see https://github.com/astronomy-commons/lsdb/issues/1317 for mode details), we should just drop this query parameter.

Fixes https://github.com/astronomy-commons/lsdb/issues/1378