### PR TITLE
fix http match failure due to fsspec backend return

### DIFF
--- a/src/hats/io/paths.py
+++ b/src/hats/io/paths.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from urllib.parse import urlencode
+from urllib.parse import urlencode, unquote
 
 from fsspec.implementations.http import HTTPFileSystem
 from upath import UPath
@@ -126,6 +126,8 @@ def get_healpix_from_path(path: str) -> HealpixPixel:
     """
     if not isinstance(path, str):
         path = str(path)
+    # HTTP fsspec backend compatibility (decode %3D etc. before matching)
+    path = unquote(path)
     healpix_path_pattern = re.compile(r".*Norder=(\d*).*Npix=(\d*).*")
     match = healpix_path_pattern.match(path)
     if not match:

--- a/src/hats/io/paths.py
+++ b/src/hats/io/paths.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from urllib.parse import urlencode, unquote
+from urllib.parse import unquote, urlencode
 
 from fsspec.implementations.http import HTTPFileSystem
 from upath import UPath
@@ -126,6 +126,7 @@ def get_healpix_from_path(path: str) -> HealpixPixel:
     """
     if not isinstance(path, str):
         path = str(path)
+
     # HTTP fsspec backend compatibility (decode %3D etc. before matching)
     path = unquote(path)
     healpix_path_pattern = re.compile(r".*Norder=(\d*).*Npix=(\d*).*")

--- a/tests/hats/io/test_paths.py
+++ b/tests/hats/io/test_paths.py
@@ -166,6 +166,12 @@ def test_get_healpix_from_path():
     result = paths.get_healpix_from_path("Norder=5/Dir=0/Npix=34.pq")
     assert result == expected
 
+    # Some fsspec backends (notably HTTP) percent-encode the path separators.
+    result = paths.get_healpix_from_path(
+        "http://0.0.0.0:8000/foo/dataset/Norder%3D5/Dir%3D0/Npix%3D34.parquet"
+    )
+    assert result == expected
+
 
 def test_get_healpix_from_path_invalid():
     expected = INVALID_PIXEL


### PR DESCRIPTION
hats-cloudtests are failing for http: https://github.com/astronomy-commons/hats-cloudtests/actions/runs/26440061270/job/77831997266

HTTP fsspec backend returns percent-encoded paths which fails a literal check currently, this should fix it by unencoding those paths

