### PR TITLE
embed sky coverage images in collection summary markdown

### DIFF
--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -7,11 +7,9 @@ from typing import Literal
 
 import human_readable
 import jinja2
-import matplotlib.pyplot as plt
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
-from matplotlib.colors import LogNorm
 from upath import UPath
 
 from hats.catalog import CollectionProperties
@@ -205,7 +203,11 @@ def generate_markdown_collection_summary(
     else:
         cone_code_example = None
 
-    pixel_map_b64, density_map_b64 = _generate_sky_coverage_images(catalog)
+    pixel_map_b64, density_map_b64 = None, None
+    try:
+        pixel_map_b64, density_map_b64 = _generate_sky_coverage_images(catalog)
+    except ImportError:
+        pass
 
     return template.render(
         name=name,
@@ -492,23 +494,21 @@ def _get_example_row(catalog: HealpixDataset) -> npd.NestedFrame | None:
     return example_nf.iloc[idx : idx + 1]
 
 
+# pylint: disable=import-outside-toplevel,import-error
 def _generate_sky_coverage_images(catalog):
-    pixel_map_b64 = None
-    density_map_b64 = None
-    try:
-        fig, _ = catalog.plot_pixels()
-        pixel_map_b64 = _fig_to_webp_base64(fig)
-    except (ImportError, ValueError):
-        pass
-    try:
-        fig, _ = plot_density(catalog, edgecolors="face", norm=LogNorm())
-        density_map_b64 = _fig_to_webp_base64(fig)
-    except (ImportError, ValueError):
-        pass
+    from matplotlib.colors import LogNorm
+
+    fig, _ = catalog.plot_pixels()
+    pixel_map_b64 = _fig_to_webp_base64(fig)
+    fig, _ = plot_density(catalog, edgecolors="face", norm=LogNorm())
+    density_map_b64 = _fig_to_webp_base64(fig)
     return pixel_map_b64, density_map_b64
 
 
+# pylint: disable=import-outside-toplevel,import-error
 def _fig_to_webp_base64(fig) -> str:
+    import matplotlib.pyplot as plt
+
     buffer = io.BytesIO()
     fig.savefig(buffer, format="webp")
     plt.close(fig)

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -1,18 +1,23 @@
+import base64
 import importlib.resources
+import io
 from itertools import starmap
 from pathlib import Path
 from typing import Literal
 
 import human_readable
 import jinja2
+import matplotlib.pyplot as plt
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
+from matplotlib.colors import LogNorm
 from upath import UPath
 
 from hats.catalog import CollectionProperties
 from hats.catalog.catalog_collection import CatalogCollection
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset
+from hats.inspection.visualize_catalog import plot_density
 from hats.io import get_common_metadata_pointer, get_partition_info_pointer, templates
 from hats.io.file_io import get_upath, read_parquet_file_to_pandas
 from hats.io.paths import get_data_thumbnail_pointer
@@ -200,6 +205,8 @@ def generate_markdown_collection_summary(
     else:
         cone_code_example = None
 
+    pixel_map_b64, density_map_b64 = _generate_sky_coverage_images(catalog)
+
     return template.render(
         name=name,
         description=description,
@@ -214,6 +221,8 @@ def generate_markdown_collection_summary(
         huggingface_metadata=huggingface_metadata,
         metadata_table=metadata_table,
         column_table=column_table,
+        pixel_map_b64=pixel_map_b64,
+        density_map_b64=density_map_b64,
     )
 
 
@@ -481,3 +490,27 @@ def _get_example_row(catalog: HealpixDataset) -> npd.NestedFrame | None:
 
     idx = rng.integers(len(example_nf))
     return example_nf.iloc[idx : idx + 1]
+
+
+def _generate_sky_coverage_images(catalog):
+    pixel_map_b64 = None
+    density_map_b64 = None
+    try:
+        fig, _ = catalog.plot_pixels()
+        pixel_map_b64 = _fig_to_webp_base64(fig)
+    except (ImportError, ValueError):
+        pass
+    try:
+        fig, _ = plot_density(catalog, edgecolors="face", norm=LogNorm())
+        density_map_b64 = _fig_to_webp_base64(fig)
+    except (ImportError, ValueError):
+        pass
+    return pixel_map_b64, density_map_b64
+
+
+def _fig_to_webp_base64(fig) -> str:
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="webp")
+    plt.close(fig)
+    buffer.seek(0)
+    return base64.b64encode(buffer.read()).decode("ascii")

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -15,7 +15,6 @@ from upath import UPath
 from hats.catalog import CollectionProperties
 from hats.catalog.catalog_collection import CatalogCollection
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset
-from hats.inspection.visualize_catalog import plot_density
 from hats.io import get_common_metadata_pointer, get_partition_info_pointer, templates
 from hats.io.file_io import get_upath, read_parquet_file_to_pandas
 from hats.io.paths import get_data_thumbnail_pointer
@@ -496,21 +495,26 @@ def _get_example_row(catalog: HealpixDataset) -> npd.NestedFrame | None:
 
 # pylint: disable=import-outside-toplevel,import-error
 def _generate_sky_coverage_images(catalog):
+    import matplotlib.figure
     from matplotlib.colors import LogNorm
 
-    fig, _ = catalog.plot_pixels()
+    from hats.inspection.visualize_catalog import plot_density
+
+    pixel_map_b64 = None
+    density_map_b64 = None
+
+    fig = matplotlib.figure.Figure(figsize=(6, 3))
+    catalog.plot_pixels(fig=fig)
     pixel_map_b64 = _fig_to_webp_base64(fig)
-    fig, _ = plot_density(catalog, edgecolors="face", norm=LogNorm())
+    fig = matplotlib.figure.Figure(figsize=(6, 3))
+    plot_density(catalog, norm=LogNorm(), fig=fig)
     density_map_b64 = _fig_to_webp_base64(fig)
     return pixel_map_b64, density_map_b64
 
 
 # pylint: disable=import-outside-toplevel,import-error
 def _fig_to_webp_base64(fig) -> str:
-    import matplotlib.pyplot as plt
 
     buffer = io.BytesIO()
     fig.savefig(buffer, format="webp")
-    plt.close(fig)
-    buffer.seek(0)
-    return base64.b64encode(buffer.read()).decode("ascii")
+    return base64.b64encode(buffer.getvalue()).decode("ascii")

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -514,7 +514,9 @@ def _generate_sky_coverage_images(catalog):
 
 # pylint: disable=import-outside-toplevel,import-error
 def _fig_to_webp_base64(fig) -> str:
+    import matplotlib.pyplot as plt
 
     buffer = io.BytesIO()
     fig.savefig(buffer, format="webp")
+    plt.close(fig)
     return base64.b64encode(buffer.getvalue()).decode("ascii")

--- a/src/hats/io/templates/default_md_template.jinja2
+++ b/src/hats/io/templates/default_md_template.jinja2
@@ -128,6 +128,6 @@ The list of default columns is available in the [`hats.properties`]({{uris["prim
 {% if pixel_map_b64 or density_map_b64 %}
 ## Sky coverage 
 
-{% if pixel_map_b64 %}![Pixel map](data:image/webp;base64,{{pixel_map_b64}}){%endif%}
-{% if density_map_b64 %}![Density map](data:image/webp;base64,{{density_map_b64}}){%endif%}
+{% if pixel_map_b64 %}![Pixel Skymap](data:image/webp;base64,{{pixel_map_b64}}){%endif%}
+{% if density_map_b64 %}![Density Skymap](data:image/webp;base64,{{density_map_b64}}){%endif%}
 {% endif %}

--- a/src/hats/io/templates/default_md_template.jinja2
+++ b/src/hats/io/templates/default_md_template.jinja2
@@ -128,6 +128,6 @@ The list of default columns is available in the [`hats.properties`]({{uris["prim
 {% if pixel_map_b64 or density_map_b64 %}
 ## Sky coverage 
 
-{% if pixel_map_b64 %}![](data:image/webp;base64,{{pixel_map_b64}}){%endif%}
-{% if density_map_b64 %}![](data:image/webp;base64,{{density_map_b64}}){%endif%}
+{% if pixel_map_b64 %}![Pixel map](data:image/webp;base64,{{pixel_map_b64}}){%endif%}
+{% if density_map_b64 %}![Density map](data:image/webp;base64,{{density_map_b64}}){%endif%}
 {% endif %}

--- a/src/hats/io/templates/default_md_template.jinja2
+++ b/src/hats/io/templates/default_md_template.jinja2
@@ -124,3 +124,10 @@ The list of default columns is available in the [`hats.properties`]({{uris["prim
 {% endif %}
 
 {% endif %}
+
+{% if pixel_map_b64 or density_map_b64 %}
+## Sky coverage 
+
+{% if pixel_map_b64 %}![](data:image/webp;base64,{{pixel_map_b64}}){%endif%}
+{% if density_map_b64 %}![](data:image/webp;base64,{{density_map_b64}}){%endif%}
+{% endif %}

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -527,6 +527,7 @@ def test_gen_md_column_table_nested_catalog(small_sky_nested_dir):
 
 
 def test_write_collection_summary_file_contains_images(tmp_path, small_sky_collection_dir):
+    pytest.importorskip("matplotlib.pyplot")
 
     collection_base_dir = tmp_path / "collection"
     shutil.copytree(small_sky_collection_dir, collection_base_dir)

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -524,3 +524,15 @@ def test_gen_md_column_table_nested_catalog(small_sky_nested_dir):
     rendered = template.render(column_table=column_table)
     assert "Nested?" in rendered
     assert "lc" in rendered
+
+
+def test_write_collection_summary_file_contains_images(tmp_path, small_sky_collection_dir):
+
+    collection_base_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_base_dir)
+
+    output_path = write_collection_summary_file(collection_base_dir, fmt="markdown")
+
+    content = output_path.read_text()
+    assert "![](data:image/webp;base64," in content
+    assert content.count("![](data:image/webp;base64,") == 2

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -535,5 +535,5 @@ def test_write_collection_summary_file_contains_images(tmp_path, small_sky_colle
     output_path = write_collection_summary_file(collection_base_dir, fmt="markdown")
 
     content = output_path.read_text()
-    assert "![Pixel map](data:image/webp;base64," in content
-    assert "![Density map](data:image/webp;base64," in content
+    assert "![Pixel Skymap](data:image/webp;base64," in content
+    assert "![Density Skymap](data:image/webp;base64," in content

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -535,5 +535,5 @@ def test_write_collection_summary_file_contains_images(tmp_path, small_sky_colle
     output_path = write_collection_summary_file(collection_base_dir, fmt="markdown")
 
     content = output_path.read_text()
-    assert "![](data:image/webp;base64," in content
-    assert content.count("![](data:image/webp;base64,") == 2
+    assert "![Pixel map](data:image/webp;base64," in content
+    assert "![Density map](data:image/webp;base64," in content


### PR DESCRIPTION
## Change Description
<!--- 
Closes #615 
-->
## Solution Description
Updated the write_collection_summary_file to generate collection plots, and was able to create a buffer in WebP that is converted to base64, and also created a test in the test_summary_file.py file that checks if the image exists.

<img width="2674" height="1782" alt="image" src="https://github.com/user-attachments/assets/24fe3560-4578-4db5-8ee5-9ed8e285051e" />

## Code Quality
- [y] I have read the Contribution Guide and agree to the Code of Conduct
- [y] My code follows the code style of this project
- [y] My code builds (or compiles) cleanly without any errors or warnings
- [y] My code contains relevant comments and necessary documentation
