### PR TITLE
add use of gen ai to Hats contribution guide

### DIFF
--- a/docs/guide/contributing.rst
+++ b/docs/guide/contributing.rst
@@ -18,6 +18,38 @@ a description.
 You can reach the team with bug reports, feature requests, and general inquiries
 by creating a new GitHub issue.
 
+Use of Generative AI
+-------------------------------------------------------------------------------
+
+Generative AI tools are often helpful. However, the output of these tools is the
+responsibility of the human contributor. LINCC Frameworks expects real authentic
+engagement in our community. As such, when using AI, please carefully consider
+what and how to communicate, question results, think things through thoroughly
+and make well-informed decisions.
+
+Some examples of acceptable and unacceptable AI uses are:
+
+**Acceptable uses**
+
+- Gaining understanding of the existing code
+- Getting solution ideas
+- Translating or proof-reading your comments or PR descriptions: please keep the
+  wording as close as possible to your original wording.
+
+**Unacceptable uses**
+
+- External AI tooling (e.g. bots, agents) directly interacting with the project;
+  including creating issues, PRs or commenting on GitHub or Discourse, including
+  good first issue PRs.
+- Solving topics that you wouldn't be able to solve yourself without AI
+- Using AI output without ensuring that you fully understand the output or without
+  verifying that it is the correct approach.
+- Increasing breadth of contributions, i.e. simultaneously contributing to several
+  projects. Instead of spreading your resources, you can provide greater value by
+  engaging more deeply with one or two projects.
+
+Adapted from `matplotlib generative ai policy <https://matplotlib.org/devdocs/devel/contribute.html#good-first-issues>`__.
+
 Create a branch
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
adds use of gen ai policy to HATS contribution guide 
## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
