### PR TITLE
Add extra template vars and file paths upport to generate_summary.py to support generation of XML files 

### DIFF
--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -437,7 +437,7 @@ def generate_summary(
         case None:
             tmpl_str = jinja2_template
         case _:
-            raise ValueError(f"Unsupported format: {fmt!r}. Expected 'markdown' or 'html'.")
+            raise ValueError(f"Unsupported format: {fmt!r}. Expected 'markdown', 'html', or None.")
     template = env.from_string(tmpl_str)
 
     is_collection = isinstance(catalog, CatalogCollection)
@@ -553,7 +553,7 @@ def write_catalog_summary_file(
             if filename is None:
                 raise ValueError("`filename` is required when `fmt` is None.")
         case _:
-            raise ValueError(f"Unsupported format: {fmt!r}. Expected 'markdown' or 'html'.")
+            raise ValueError(f"Unsupported format: {fmt!r}. Expected 'markdown', 'html', or None.")
     catalog = read_hats(catalog_path)
 
     if isinstance(catalog, CatalogCollection):

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -374,12 +374,13 @@ def write_partition_info_png(catalog_path: str | Path | UPath) -> None:
 def generate_summary(
     catalog,
     *,
-    fmt: Literal["markdown", "html"],
+    fmt: Literal["markdown", "html"] | None = None,
     name: str,
     description: str,
     uri: str | None,
     huggingface_metadata: bool,
     jinja2_template: str | None = None,
+    **extra_template_vars,
 ) -> str:
     """Generate summary content for any HATS catalog or collection."""
     if isinstance(catalog, CatalogCollection):
@@ -391,11 +392,17 @@ def generate_summary(
     else:
         md_tmpl, html_tmpl = "catalog_md_template.jinja2", "catalog_html_template.jinja2"
     env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+
+    if jinja2_template is not None and Path(jinja2_template).exists():
+        jinja2_template = Path(jinja2_template).read_text(encoding="utf-8")
+
     match fmt:
         case "markdown":
             tmpl_str = jinja2_template or importlib.resources.read_text(templates, md_tmpl)
         case "html":
             tmpl_str = jinja2_template or importlib.resources.read_text(templates, html_tmpl)
+        case None:
+            tmpl_str = jinja2_template
         case _:
             raise ValueError(f"Unsupported format: {fmt!r}. Expected 'markdown' or 'html'.")
     template = env.from_string(tmpl_str)
@@ -411,7 +418,6 @@ def generate_summary(
     column_table = _gen_column_table(inner, empty_nf)
     col_props = catalog.collection_properties if is_collection else None
     needs_sky = not isinstance(catalog, (MarginCatalog, IndexCatalog))
-    has_default_columns = bool(cat_props.default_columns) if needs_sky else None
     cone_code_example = _cone_code_example(column_table, cat_props) if needs_sky else None
     pixel_map_b64, density_map_b64 = None, None
     if needs_sky:
@@ -434,20 +440,21 @@ def generate_summary(
         ),
         column_table=pd.DataFrame() if isinstance(catalog, IndexCatalog) else column_table,
         catalog_dir_name=None if is_collection else catalog.catalog_path.name,
-        has_default_columns=has_default_columns,
+        has_default_columns=bool(cat_props.default_columns) if needs_sky else None,
         cone_code_example=cone_code_example,
         pixel_map_b64=pixel_map_b64,
         density_map_b64=density_map_b64,
         col_props=col_props,
         uris=_catalog_uris(col_props, uri) if is_collection else None,
         margin_thresholds=catalog.get_margin_thresholds() if is_collection else None,
+        **extra_template_vars,
     )
 
 
 def write_catalog_summary_file(
     catalog_path: str | Path | UPath,
     *,
-    fmt: Literal["markdown", "html"],
+    fmt: Literal["markdown", "html"] | None = None,
     filename: str | None = None,
     output_dir: str | Path | UPath | None = None,
     name: str | None = None,
@@ -455,6 +462,7 @@ def write_catalog_summary_file(
     uri: str | None = None,
     huggingface_metadata: bool = False,
     jinja2_template: str | None = None,
+    **extra_template_vars,
 ) -> UPath:
     """Write a summary readme file for any HATS catalog or collection"""
     from hats.catalog.catalog import Catalog
@@ -467,6 +475,11 @@ def write_catalog_summary_file(
             filename = filename or "README.md"
         case "html":
             filename = filename or "index.html"
+        case None:
+            if jinja2_template is None:
+                raise ValueError("Either `fmt` or `jinja2_template` must be provided.")
+            if filename is None:
+                raise ValueError("`filename` is required when `fmt` is None.")
         case _:
             raise ValueError(f"Unsupported format: {fmt!r}. Expected 'markdown' or 'html'.")
     catalog = read_hats(catalog_path)
@@ -497,6 +510,7 @@ def write_catalog_summary_file(
         uri=uri,
         huggingface_metadata=huggingface_metadata,
         jinja2_template=jinja2_template,
+        **extra_template_vars,
     )
 
     output_dir = catalog_path if output_dir is None else get_upath(output_dir)

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -380,9 +380,42 @@ def generate_summary(
     uri: str | None,
     huggingface_metadata: bool,
     jinja2_template: str | None = None,
-    **extra_template_vars,
+    extra_template_vars: dict | None = None,
 ) -> str:
-    """Generate summary content for any HATS catalog or collection."""
+    """Generate summary content for any HATS catalog or collection.
+
+    Parameters
+    ----------
+    catalog : Catalog | CatalogCollection
+        The HATS catalog or collection to summarize.
+    fmt : Literal["markdown", "html"] | None
+        Output format. Use ``"markdown"`` or ``"html"`` to render the built-in
+        template, or ``None`` to supply a fully custom ``jinja2_template``.
+    name : str
+        Human-readable name rendered in the summary.
+    description : str
+        Description rendered in the summary.
+    uri : str | None
+        URI of the catalog used for hyperlinks and code-snippet examples.
+        If ``None``, a placeholder is used.
+    huggingface_metadata : bool
+        Whether to include Hugging Face YAML frontmatter. Only valid when
+        ``fmt="markdown"``.
+    jinja2_template : str | None
+        Jinja2 template string or path to a ``.jinja2`` file. If a file path
+        is given, the file is read automatically. Overrides the built-in
+        template when ``fmt`` is ``"markdown"`` or ``"html"``; required when
+        ``fmt=None``.
+    extra_template_vars : dict | None
+        Additional variables passed into ``template.render()``. Useful for
+        custom templates (e.g. VO registry XML fields) that reference variables
+        HATS does not supply by default.
+
+    Returns
+    -------
+    str
+        Rendered summary content.
+    """
     if isinstance(catalog, CatalogCollection):
         md_tmpl, html_tmpl = "collection_md_template.jinja2", "collection_html_template.jinja2"
     elif isinstance(catalog, MarginCatalog):
@@ -395,7 +428,7 @@ def generate_summary(
 
     if jinja2_template is not None and Path(jinja2_template).exists():
         jinja2_template = Path(jinja2_template).read_text(encoding="utf-8")
-
+        # sets jinja_template as a file as a path
     match fmt:
         case "markdown":
             tmpl_str = jinja2_template or importlib.resources.read_text(templates, md_tmpl)
@@ -447,14 +480,14 @@ def generate_summary(
         col_props=col_props,
         uris=_catalog_uris(col_props, uri) if is_collection else None,
         margin_thresholds=catalog.get_margin_thresholds() if is_collection else None,
-        **extra_template_vars,
+        **(extra_template_vars or {}),
     )
 
 
 def write_catalog_summary_file(
     catalog_path: str | Path | UPath,
     *,
-    fmt: Literal["markdown", "html"] | None = None,
+    fmt: Literal["markdown", "html"] | None,
     filename: str | None = None,
     output_dir: str | Path | UPath | None = None,
     name: str | None = None,
@@ -462,9 +495,48 @@ def write_catalog_summary_file(
     uri: str | None = None,
     huggingface_metadata: bool = False,
     jinja2_template: str | None = None,
-    **extra_template_vars,
+    extra_template_vars: dict | None = None,
 ) -> UPath:
-    """Write a summary readme file for any HATS catalog or collection"""
+    """Write a summary readme file for any HATS catalog or collection.
+
+    Parameters
+    ----------
+    catalog_path : str | Path | UPath
+        Path to the HATS catalog or collection directory.
+    fmt : Literal["markdown", "html"] | None
+        Output format. Use ``"markdown"`` (writes ``README.md``) or ``"html"``
+        (writes ``index.html``), or ``None`` to supply a fully custom
+        ``jinja2_template`` and ``filename``.
+    filename : str | None
+        Output filename. Defaults to ``README.md`` for markdown and
+        ``index.html`` for HTML. Required when ``fmt=None``.
+    output_dir : str | Path | UPath | None
+        Directory to write the file to. Defaults to ``catalog_path``.
+    name : str | None
+        Human-readable name. Inferred from catalog metadata if not provided.
+    description : str | None
+        Description. Inferred from catalog metadata if not provided.
+    uri : str | None
+        URI of the catalog used for hyperlinks and code-snippet examples.
+        If ``None``, a placeholder is used.
+    huggingface_metadata : bool
+        Whether to include Hugging Face YAML frontmatter. Only valid when
+        ``fmt="markdown"``.
+    jinja2_template : str | None
+        Jinja2 template string or path to a ``.jinja2`` file. If a file path
+        is given, the file is read automatically. Overrides the built-in
+        template when ``fmt`` is ``"markdown"`` or ``"html"``; required when
+        ``fmt=None``.
+    extra_template_vars : dict | None
+        Additional variables passed into ``template.render()``. Useful for
+        custom templates (e.g. VO registry XML fields) that reference variables
+        HATS does not supply by default.
+
+    Returns
+    -------
+    UPath
+        Path to the written summary file.
+    """
     from hats.catalog.catalog import Catalog
 
     catalog_path = get_upath(catalog_path)
@@ -477,7 +549,7 @@ def write_catalog_summary_file(
             filename = filename or "index.html"
         case None:
             if jinja2_template is None:
-                raise ValueError("Either `fmt` or `jinja2_template` must be provided.")
+                raise ValueError("`jinja2_template` is required when `fmt` is None.")
             if filename is None:
                 raise ValueError("`filename` is required when `fmt` is None.")
         case _:
@@ -510,7 +582,7 @@ def write_catalog_summary_file(
         uri=uri,
         huggingface_metadata=huggingface_metadata,
         jinja2_template=jinja2_template,
-        **extra_template_vars,
+        extra_template_vars=extra_template_vars,
     )
 
     output_dir = catalog_path if output_dir is None else get_upath(output_dir)

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -575,7 +575,6 @@ def test_write_catalog_summary_file_invalid_format_raises(tmp_path, small_sky_co
 
 
 def test_write_catalog_summary_file_fmt_none_template_file_path(tmp_path, small_sky_order1_dir):
-    """fmt=None with a template FILE PATH reads the file and renders it"""
     dest = tmp_path / small_sky_order1_dir.name
     shutil.copytree(small_sky_order1_dir, dest)
     tmpl_file = tmp_path / "my_template.xml.jinja2"
@@ -583,7 +582,7 @@ def test_write_catalog_summary_file_fmt_none_template_file_path(tmp_path, small_
     output_path = write_catalog_summary_file(
         dest,
         fmt=None,
-        filename="registry.xml",
+        filename="test.xml",
         jinja2_template=str(tmpl_file),
     )
     content = output_path.read_text()
@@ -592,19 +591,45 @@ def test_write_catalog_summary_file_fmt_none_template_file_path(tmp_path, small_
 
 
 def test_write_catalog_summary_file_extra_template_vars(tmp_path, small_sky_order1_dir):
-    """**extra_template_vars are forwarded into the template"""
     dest = tmp_path / small_sky_order1_dir.name
     shutil.copytree(small_sky_order1_dir, dest)
     output_path = write_catalog_summary_file(
         dest,
         fmt=None,
-        filename="registry.xml",
-        jinja2_template="<url>{{ access_url }}</url><name>{{ name }}</name>",
+        filename="test.xml",
+        jinja2_template="<url>{{access_url}}</url><name>{{name}}</name>",
         access_url="https://data.lsdb.io/small_sky",
     )
     content = output_path.read_text()
     assert "<url>https://data.lsdb.io/small_sky</url>" in content
     assert "<name>small_sky_order1</name>" in content
+
+
+def test_write_catalog_summary_file_fmt_none_requires_template(tmp_path, small_sky_order1_dir):
+    dest = tmp_path / small_sky_order1_dir.name
+    shutil.copytree(small_sky_order1_dir, dest)
+    with pytest.raises(ValueError, match="jinja2_template"):
+        write_catalog_summary_file(dest, fmt=None, filename="out.xml")
+
+
+def test_write_catalog_summary_file_fmt_none_requires_filename(tmp_path, small_sky_order1_dir):
+    dest = tmp_path / small_sky_order1_dir.name
+    shutil.copytree(small_sky_order1_dir, dest)
+    with pytest.raises(ValueError, match="filename"):
+        write_catalog_summary_file(dest, fmt=None, jinja2_template="{{ name }}")
+
+
+def test_generate_summary_unsupported_fmt_raises(small_sky_order1_dir):
+    catalog = read_hats(small_sky_order1_dir)
+    with pytest.raises(ValueError, match="Unsupported format"):
+        generate_summary(
+            catalog,
+            fmt="xml",
+            name="test",
+            description="test",
+            uri=None,
+            huggingface_metadata=False,
+        )
 
 
 def test_write_skymap_png(tmp_path, small_sky_order1_dir):

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -574,6 +574,39 @@ def test_write_catalog_summary_file_invalid_format_raises(tmp_path, small_sky_co
         write_catalog_summary_file(collection_base_dir, fmt="md")
 
 
+def test_write_catalog_summary_file_fmt_none_template_file_path(tmp_path, small_sky_order1_dir):
+    """fmt=None with a template FILE PATH reads the file and renders it"""
+    dest = tmp_path / small_sky_order1_dir.name
+    shutil.copytree(small_sky_order1_dir, dest)
+    tmpl_file = tmp_path / "my_template.xml.jinja2"
+    tmpl_file.write_text("<desc>{{ description }}</desc>")
+    output_path = write_catalog_summary_file(
+        dest,
+        fmt=None,
+        filename="registry.xml",
+        jinja2_template=str(tmpl_file),
+    )
+    content = output_path.read_text()
+    assert content.startswith("<desc>")
+    assert "small_sky_order1" in content
+
+
+def test_write_catalog_summary_file_extra_template_vars(tmp_path, small_sky_order1_dir):
+    """**extra_template_vars are forwarded into the template"""
+    dest = tmp_path / small_sky_order1_dir.name
+    shutil.copytree(small_sky_order1_dir, dest)
+    output_path = write_catalog_summary_file(
+        dest,
+        fmt=None,
+        filename="registry.xml",
+        jinja2_template="<url>{{ access_url }}</url><name>{{ name }}</name>",
+        access_url="https://data.lsdb.io/small_sky",
+    )
+    content = output_path.read_text()
+    assert "<url>https://data.lsdb.io/small_sky</url>" in content
+    assert "<name>small_sky_order1</name>" in content
+
+
 def test_write_skymap_png(tmp_path, small_sky_order1_dir):
     pytest.importorskip("matplotlib.pyplot")
     dest = tmp_path / small_sky_order1_dir.name

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -598,7 +598,7 @@ def test_write_catalog_summary_file_extra_template_vars(tmp_path, small_sky_orde
         fmt=None,
         filename="test.xml",
         jinja2_template="<url>{{access_url}}</url><name>{{name}}</name>",
-        access_url="https://data.lsdb.io/small_sky",
+        extra_template_vars={"access_url": "https://data.lsdb.io/small_sky"},
     )
     content = output_path.read_text()
     assert "<url>https://data.lsdb.io/small_sky</url>" in content
@@ -608,15 +608,15 @@ def test_write_catalog_summary_file_extra_template_vars(tmp_path, small_sky_orde
 def test_write_catalog_summary_file_fmt_none_requires_template(tmp_path, small_sky_order1_dir):
     dest = tmp_path / small_sky_order1_dir.name
     shutil.copytree(small_sky_order1_dir, dest)
-    with pytest.raises(ValueError, match="jinja2_template"):
+    with pytest.raises(ValueError, match="`jinja2_template` is required"):
         write_catalog_summary_file(dest, fmt=None, filename="out.xml")
 
 
 def test_write_catalog_summary_file_fmt_none_requires_filename(tmp_path, small_sky_order1_dir):
     dest = tmp_path / small_sky_order1_dir.name
     shutil.copytree(small_sky_order1_dir, dest)
-    with pytest.raises(ValueError, match="filename"):
-        write_catalog_summary_file(dest, fmt=None, jinja2_template="{{ name }}")
+    with pytest.raises(ValueError, match="`filename` is required"):
+        write_catalog_summary_file(dest, fmt=None, jinja2_template="{{name}}")
 
 
 def test_generate_summary_unsupported_fmt_raises(small_sky_order1_dir):


### PR DESCRIPTION
write_catalog_summary_file in summary_file.py only supported md and html formats using built in templates. There was no way to generate a VO registry XML file (or any other custom format). Now, when you pass fmt=None, you can supply your own jinja2 template (as a string or file path) and your own filename. I also added an option to add extra kwargs that might be needed for the VO registry. 



## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
