### PR TITLE
don't check against nested-pandas main

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-git+https://github.com/lincc-frameworks/nested-pandas.git@main
 datasets


### PR DESCRIPTION
nested-pandas main will not always support hats/lsdb/hats-import, and because we utilize minor version pinning to control compatibility that should be sufficient.