### PR TITLE
Swap info in PNGs. Friendlier errors.

### DIFF
--- a/src/hats/io/skymap.py
+++ b/src/hats/io/skymap.py
@@ -60,6 +60,8 @@ def read_skymap(catalog, order):
 
     ## Deprecated - prefer reading skymap.fits to reading point_map.fits
     map_file_pointer = paths.get_point_map_file_pointer(catalog.catalog_base_dir)
+    if not map_file_pointer.exists():
+        raise FileNotFoundError("No skymap file found in catalog directory.")
     point_map = file_io.read_fits_image(map_file_pointer)
     point_map_order = hp.npix2order(len(point_map))
     if order is None or order == point_map_order:

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -339,12 +339,18 @@ def write_skymap_png(catalog_path: str | Path | UPath) -> None:
         Path to the catalog directory. The PNG will be written alongside
         the catalog's other files.
     """
-    import matplotlib.pyplot as plt
+    try:
+        import matplotlib.pyplot as plt
+        from matplotlib.colors import LogNorm
+
+        from hats.inspection.visualize_catalog import plot_density
+    except ImportError as exc:
+        raise ImportError("matplotlib is required to use this method. Install with pip or conda.") from exc
 
     catalog = read_hats(get_upath(catalog_path))
     inner = catalog.main_catalog if isinstance(catalog, CatalogCollection) else catalog
 
-    fig, _ = inner.plot_pixels()
+    fig, _ = plot_density(inner, norm=LogNorm(), edgecolors="face")
     with (get_upath(catalog_path) / "skymap.png").open("wb") as f:
         fig.savefig(f, format="png", bbox_inches="tight")
     plt.close(fig)
@@ -360,15 +366,15 @@ def write_partition_info_png(catalog_path: str | Path | UPath) -> None:
         Path to the catalog directory. The PNG will be written alongside
         the catalog's other files.
     """
-    import matplotlib.pyplot as plt
-    from matplotlib.colors import LogNorm
-
-    from hats.inspection.visualize_catalog import plot_density
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise ImportError("matplotlib is required to use this method. Install with pip or conda.") from exc
 
     catalog = read_hats(get_upath(catalog_path))
     inner = catalog.main_catalog if isinstance(catalog, CatalogCollection) else catalog
 
-    fig, _ = plot_density(inner, norm=LogNorm(), edgecolors="face")
+    fig, _ = inner.plot_pixels()
     with (get_upath(catalog_path) / "partition_info.png").open("wb") as f:
         fig.savefig(f, format="png", bbox_inches="tight")
     plt.close(fig)


### PR DESCRIPTION
## Change Description

- the `partition_info.png` showed the skymap that i would expect in `skymap.png`
- the `skymap.png` showed the partition pixel plot i would expect in `partition_info.png`
- it's easy not to notice when you're generating and showing each one all the time =D
- similar to other places where we're doing a method-level import, re-raise import errors to improve the error message
- also give a friendlier error message for no `skymap.fits` or `point_map.fits` in the catalog's directory (that was what originally brought me down this path; "that's a weird error, and why is it even looking for a `point_map.fits` in the `write_partition_info_png` call?")