### PR TITLE
Add `warn_on_modified_catalog` flag to statistics methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/astronomy-commons/lsdb/blob/main/docs/lincc-logo.png?raw=true" width="300" height="100">
+<img src="https://github.com/astronomy-commons/lsdb/blob/main/docs/lincc-logo.png?raw=true" width="300">
 
 # HATS
 

--- a/src/hats/catalog/dataset/dataset.py
+++ b/src/hats/catalog/dataset/dataset.py
@@ -71,9 +71,11 @@ class Dataset:
 
     def aggregate_column_statistics(
         self,
+        *,
         exclude_hats_columns: bool = True,
         exclude_columns: list[str] = None,
         include_columns: list[str] = None,
+        warn_on_modified_catalog: bool = True,
     ):
         """Read footer statistics in parquet metadata, and report on global min/max values.
 
@@ -87,6 +89,9 @@ class Dataset:
         include_columns : list[str]
             if specified, only return statistics for the column
             names provided. Defaults to None, and returns all non-hats columns.
+        warn_on_modified_catalog : bool
+            if True, this method will warn if the catalog has been modified from its original on-disk
+            state. Defaults to True.
 
         Returns
         -------
@@ -96,7 +101,7 @@ class Dataset:
         if not self.on_disk:
             warnings.warn("Calling aggregate_column_statistics on an in-memory catalog. No results.")
             return pd.DataFrame()
-        if not self.unmodified:
+        if warn_on_modified_catalog and not self.unmodified:
             warnings.warn(
                 "Calling aggregate_column_statistics on a modified catalog. Results may be inaccurate."
             )
@@ -122,6 +127,7 @@ class Dataset:
         include_stats: list[str] | None = None,
         multi_index=False,
         per_row_group: bool = False,
+        warn_on_modified_catalog: bool = True,
     ):
         """Read footer statistics in parquet metadata, and report on statistics about
         each pixel partition."""
@@ -133,6 +139,7 @@ class Dataset:
             include_stats=include_stats,
             multi_index=multi_index,
             per_row_group=per_row_group,
+            warn_on_modified_catalog=warn_on_modified_catalog,
         )
 
     def per_partition_statistics(
@@ -145,6 +152,7 @@ class Dataset:
         include_stats: list[str] = None,
         multi_index=False,
         per_row_group: bool = False,
+        warn_on_modified_catalog: bool = True,
     ):
         """Read footer statistics in parquet metadata, and report on statistics about
         each pixel partition.
@@ -166,6 +174,9 @@ class Dataset:
             pixel, then on column name? Default is False, and instead indexes on pixel, with
             separate columns per-data-column and stat value combination.
             (Default value = False)
+        warn_on_modified_catalog : bool
+            if True, this method will warn if the catalog has been modified from its original on-disk
+            state. Defaults to True.
 
         Returns
         -------
@@ -175,7 +186,7 @@ class Dataset:
         if not self.on_disk:
             warnings.warn("Calling per_partition_statistics on an in-memory catalog. No results.")
             return pd.DataFrame()
-        if not self.unmodified:
+        if warn_on_modified_catalog and not self.unmodified:
             warnings.warn(
                 "Calling per_partition_statistics on a modified catalog. Results may be inaccurate."
             )

--- a/src/hats/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hats/catalog/healpix_dataset/healpix_dataset.py
@@ -310,11 +310,13 @@ class HealpixDataset(Dataset):
 
     def aggregate_column_statistics(
         self,
+        *,
         exclude_hats_columns: bool = True,
         exclude_columns: list[str] | None = None,
         include_columns: list[str] | None = None,
         only_numeric_columns: bool = False,
         include_pixels: list[HealpixPixel] | None = None,
+        warn_on_modified_catalog: bool = True,
     ):
         """Read footer statistics in parquet metadata, and report on global min/max values.
 
@@ -334,6 +336,9 @@ class HealpixDataset(Dataset):
             (Default value = False)
         include_pixels: list[HealpixPixel] | None
             (Default value = None)
+        warn_on_modified_catalog : bool
+            if True, this method will warn if the catalog has been modified from its original on-disk
+            state. Defaults to True.
 
         Returns
         -------
@@ -343,7 +348,7 @@ class HealpixDataset(Dataset):
         if not self.on_disk:
             warnings.warn("Calling aggregate_column_statistics on an in-memory catalog. No results.")
             return pd.DataFrame()
-        if not self.unmodified:
+        if warn_on_modified_catalog and not self.unmodified:
             warnings.warn(
                 "Calling aggregate_column_statistics on a modified catalog. Results may be inaccurate."
             )
@@ -374,7 +379,7 @@ class HealpixDataset(Dataset):
         reason="`per_pixel_statistics` will be removed in the future, "
         "use `per_partition_statistics` instead.",
     )
-    def per_pixel_statistics(
+    def per_pixel_statistics(  # pylint: disable=duplicate-code
         self,
         *,
         exclude_hats_columns: bool = True,
@@ -385,6 +390,7 @@ class HealpixDataset(Dataset):
         multi_index=False,
         include_pixels: list[HealpixPixel] | None = None,
         per_row_group: bool = False,
+        warn_on_modified_catalog: bool = True,
     ):
         return self.per_partition_statistics(
             exclude_hats_columns=exclude_hats_columns,
@@ -395,6 +401,7 @@ class HealpixDataset(Dataset):
             multi_index=multi_index,
             include_pixels=include_pixels,
             per_row_group=per_row_group,
+            warn_on_modified_catalog=warn_on_modified_catalog,
         )
 
     def per_partition_statistics(
@@ -408,6 +415,7 @@ class HealpixDataset(Dataset):
         multi_index=False,
         include_pixels: list[HealpixPixel] | None = None,
         per_row_group: bool = False,
+        warn_on_modified_catalog: bool = True,
     ):
         """Read footer statistics in parquet metadata, and report on statistics about
         each pixel partition.
@@ -431,6 +439,9 @@ class HealpixDataset(Dataset):
         include_pixels : list[HealpixPixel] | None
             if specified, only return statistics
             for the pixels indicated. Defaults to none, and returns all pixels.
+        warn_on_modified_catalog : bool
+            if True, this method will warn if the catalog has been modified from its original on-disk
+            state. Defaults to True.
 
         Returns
         -------
@@ -440,7 +451,7 @@ class HealpixDataset(Dataset):
         if not self.on_disk:
             warnings.warn("Calling per_partition_statistics on an in-memory catalog. No results.")
             return pd.DataFrame()
-        if not self.unmodified:
+        if warn_on_modified_catalog and not self.unmodified:
             warnings.warn(
                 "Calling per_partition_statistics on a modified catalog. Results may be inaccurate."
             )

--- a/tests/hats/catalog/test_catalog.py
+++ b/tests/hats/catalog/test_catalog.py
@@ -1,6 +1,7 @@
 """Tests of catalog functionality"""
 
 import os
+import warnings
 
 import astropy.units as u
 import numpy as np
@@ -134,6 +135,12 @@ def test_catalog_statistics(small_sky_order1_dir):
     assert len(result_frame) == 5
     assert_column_stat_as_floats(result_frame, "dec", min_value=-69.5, max_value=-47.5, row_count=42)
 
+    # No warning is raised on a modified catalog when warn_on_modified_catalog=False.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result_frame = filtered_catalog.aggregate_column_statistics(warn_on_modified_catalog=False)
+    assert len(result_frame) == 5
+
     result_frame = cat.per_partition_statistics()
     # 4 = 4 pixels
     # 30 = 5 columns * 6 stats per-column
@@ -155,6 +162,12 @@ def test_catalog_statistics(small_sky_order1_dir):
         result_frame = filtered_catalog.per_partition_statistics()
     # 1 = 1 pixel (the filtered catalog has only one pixel)
     # 30 = 5 columns * 6 stats per-column
+    assert result_frame.shape == (1, 30)
+
+    # No warning is raised on a modified catalog when warn_on_modified_catalog=False.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result_frame = filtered_catalog.per_partition_statistics(warn_on_modified_catalog=False)
     assert result_frame.shape == (1, 30)
 
 


### PR DESCRIPTION
Add a `warn_on_modified_catalog` flag to the statistics methods following https://github.com/astronomy-commons/lsdb/pull/1474#discussion_r3573272851. 

Unrelated, but it also performs a very small dimension fix in the LINCC Frameworks logo.