### PR TITLE
Use consistent float serialization in table properties.

### DIFF
--- a/src/hats/catalog/dataset/table_properties.py
+++ b/src/hats/catalog/dataset/table_properties.py
@@ -173,6 +173,19 @@ class TableProperties(BaseModel):
 
     @field_serializer("margin_threshold", "assn_max_separation", "moc_sky_fraction")
     def serialize_float(self, value: float | None) -> str:
+        """Convert a floating point number to a string representation, rounding to
+        5 decimal places.
+
+        Parameters
+        ----------
+        value: float
+            floating point value (or None, if the field is empty)
+
+        Returns
+        -------
+        str
+            string representation of the float, rounded to 5 places, or None if input is None
+        """
         if value is None:
             return None
         return f"{round(value, 5)}"

--- a/src/hats/catalog/dataset/table_properties.py
+++ b/src/hats/catalog/dataset/table_properties.py
@@ -171,6 +171,12 @@ class TableProperties(BaseModel):
         int_list.sort()
         return int_list
 
+    @field_serializer("margin_threshold", "assn_max_separation", "moc_sky_fraction")
+    def serialize_float(self, value: float | None) -> str:
+        if value is None:
+            return None
+        return f"{round(value, 5)}"
+
     @field_serializer("default_columns", "extra_columns", "skymap_alt_orders")
     def serialize_as_space_delimited_list(self, str_list: Iterable) -> str:
         """Convert a python list of strings into a space-delimited string.


### PR DESCRIPTION
## Change Description

There are mixed implmentations of how many decimal places to include in the hats.properties file for the few floating point fields.

This attempts to make the rounding occur just before the file is written to disk.