### PR TITLE
Use relative or absolute path for collection sub-tables.

### DIFF
--- a/src/hats/catalog/catalog_collection.py
+++ b/src/hats/catalog/catalog_collection.py
@@ -6,6 +6,7 @@ from hats.catalog.catalog import Catalog
 from hats.catalog.catalog_type import CatalogType
 from hats.catalog.dataset.collection_properties import CollectionProperties
 from hats.catalog.dataset.table_properties import TableProperties
+from hats.io import file_io
 from hats.pixel_math import HealpixPixel
 
 
@@ -43,7 +44,9 @@ class CatalogCollection:
     @property
     def main_catalog_dir(self) -> UPath:
         """Path to the main catalog directory"""
-        return self.collection_path / self.collection_properties.hats_primary_table_url
+        return self.resolve_inner_path(
+            self.collection_path, self.collection_properties.hats_primary_table_url
+        )
 
     @property
     def all_margins(self) -> list[str] | None:
@@ -60,7 +63,7 @@ class CatalogCollection:
         """Path to the default margin catalog directory"""
         if self.default_margin is None:
             return None
-        return self.collection_path / self.default_margin
+        return self.resolve_inner_path(self.collection_path, self.default_margin)
 
     @property
     def all_indexes(self) -> dict[str, str] | None:
@@ -87,7 +90,7 @@ class CatalogCollection:
         if self.all_indexes is None or field_name not in self.all_indexes:
             raise ValueError(f"Index for field `{field_name}` is not specified in all_indexes")
         index_dir = self.all_indexes[field_name]
-        return self.collection_path / index_dir
+        return self.resolve_inner_path(self.collection_path, index_dir)
 
     def get_healpix_pixels(self) -> list[HealpixPixel]:
         """The list of HEALPix pixels of the main catalog"""
@@ -119,3 +122,11 @@ class CatalogCollection:
             thresholds[margin_name] = margin_properties.margin_threshold
 
         return thresholds
+
+    @classmethod
+    def resolve_inner_path(cls, collection_path, path) -> UPath:
+        path = file_io.get_upath(path)
+        if "local" not in path.fs.protocol or path.is_absolute():
+            return path  # remote URL or absolute local path - use as-is
+        collection_path = file_io.get_upath(collection_path)
+        return collection_path / path

--- a/src/hats/catalog/catalog_collection.py
+++ b/src/hats/catalog/catalog_collection.py
@@ -33,6 +33,7 @@ class CatalogCollection:
         collection_path: UPath,
         collection_properties: CollectionProperties,
         main_catalog: Catalog,
+        storage_options: dict | None = None,
     ):
         self.collection_path = collection_path
         self.collection_properties = collection_properties
@@ -40,12 +41,13 @@ class CatalogCollection:
         if not isinstance(main_catalog, Catalog):
             raise TypeError(f"HATS at {main_catalog.catalog_path} is not of type `Catalog`")
         self.main_catalog = main_catalog
+        self.storage_options = storage_options
 
     @property
     def main_catalog_dir(self) -> UPath:
         """Path to the main catalog directory"""
         return self.resolve_inner_path(
-            self.collection_path, self.collection_properties.hats_primary_table_url
+            self.collection_path, self.collection_properties.hats_primary_table_url, self.storage_options
         )
 
     @property
@@ -63,7 +65,7 @@ class CatalogCollection:
         """Path to the default margin catalog directory"""
         if self.default_margin is None:
             return None
-        return self.resolve_inner_path(self.collection_path, self.default_margin)
+        return self.resolve_inner_path(self.collection_path, self.default_margin, self.storage_options)
 
     @property
     def all_indexes(self) -> dict[str, str] | None:
@@ -90,7 +92,7 @@ class CatalogCollection:
         if self.all_indexes is None or field_name not in self.all_indexes:
             raise ValueError(f"Index for field `{field_name}` is not specified in all_indexes")
         index_dir = self.all_indexes[field_name]
-        return self.resolve_inner_path(self.collection_path, index_dir)
+        return self.resolve_inner_path(self.collection_path, index_dir, self.storage_options)
 
     def get_healpix_pixels(self) -> list[HealpixPixel]:
         """The list of HEALPix pixels of the main catalog"""
@@ -159,7 +161,7 @@ class CatalogCollection:
         return thresholds
 
     @classmethod
-    def resolve_inner_path(cls, collection_path, path) -> UPath:
+    def resolve_inner_path(cls, collection_path, path, storage_options: dict | None = None) -> UPath:
         """Convenience method to find the path of a related catalog, either relative or absolute.
 
         Parameters
@@ -168,13 +170,19 @@ class CatalogCollection:
             fully-specified path to the collection root
         path: UPath | Path | str
             location of the related catalog
+        storage_options: dict
+            dictionary of storage options for the connection to the related catalog
 
         Returns
         -------
         UPath
             fully-specified path to the related catalog.
         """
-        path = file_io.get_upath(path)
+
+        if storage_options is None:
+            storage_options = {}
+
+        path = file_io.get_upath(path, **storage_options)
         if "local" not in path.fs.protocol or path.is_absolute():
             return path  # remote URL or absolute local path - use as-is
         collection_path = file_io.get_upath(collection_path)

--- a/src/hats/catalog/catalog_collection.py
+++ b/src/hats/catalog/catalog_collection.py
@@ -160,6 +160,20 @@ class CatalogCollection:
 
     @classmethod
     def resolve_inner_path(cls, collection_path, path) -> UPath:
+        """Convenience method to find the path of a related catalog, either relative or absolute.
+
+        Parameters
+        ----------
+        collection_path: UPath
+            fully-specified path to the collection root
+        path: UPath | Path | str
+            location of the related catalog
+
+        Returns
+        -------
+        UPath
+            fully-specified path to the related catalog.
+        """
         path = file_io.get_upath(path)
         if "local" not in path.fs.protocol or path.is_absolute():
             return path  # remote URL or absolute local path - use as-is

--- a/src/hats/io/file_io/file_pointer.py
+++ b/src/hats/io/file_io/file_pointer.py
@@ -32,6 +32,18 @@ def get_upath(path: str | Path | UPath, **kwargs) -> UPath:
     return get_upath_for_protocol(path, **kwargs)
 
 
+def _dictionary_recursive_merge(dict1, dict2):
+    """Recursively merges dict2 into dict1."""
+    for key, value in dict2.items():
+        # If both values are dictionaries, recurse down
+        if key in dict1 and isinstance(dict1[key], dict) and isinstance(value, dict):
+            _dictionary_recursive_merge(dict1[key], value)
+        else:
+            # Otherwise, overwrite or add the value
+            dict1[key] = value
+    return dict1
+
+
 def get_upath_for_protocol(path: str | Path, **kwargs) -> UPath:
     """Create UPath with protocol-specific configurations.
 
@@ -58,10 +70,13 @@ def get_upath_for_protocol(path: str | Path, **kwargs) -> UPath:
         } | kwargs
         upath = UPath(path, **kwargs)
     if upath.protocol in ("http", "https"):
-        kwargs = kwargs | {
-            "block_size": BLOCK_SIZE,
-            "client_kwargs": {"headers": {"User-Agent": f"hats/{version('hats')}"}},
-        }
+        kwargs = _dictionary_recursive_merge(
+            {
+                "block_size": BLOCK_SIZE,
+                "client_kwargs": {"headers": {"User-Agent": f"hats/{version('hats')}"}},
+            },
+            kwargs,
+        )
 
         parts = urlparse(path)
         if parts.netloc == _VIZCAT_HOST:

--- a/src/hats/io/file_io/file_pointer.py
+++ b/src/hats/io/file_io/file_pointer.py
@@ -10,13 +10,15 @@ BLOCK_SIZE = 32 * 1024
 _VIZCAT_HOST = "vizcat.cds.unistra.fr"
 
 
-def get_upath(path: str | Path | UPath) -> UPath:
+def get_upath(path: str | Path | UPath, **kwargs) -> UPath:
     """Returns a UPath file pointer from a path string or other path-like type.
 
     Parameters
     ----------
     path: str | Path | UPath
         base file path to be normalized to UPath
+    **kwargs
+        additional storage options required for the file system backend.
 
     Returns
     -------
@@ -27,10 +29,10 @@ def get_upath(path: str | Path | UPath) -> UPath:
         return None
     if isinstance(path, UPath):
         return path
-    return get_upath_for_protocol(path)
+    return get_upath_for_protocol(path, **kwargs)
 
 
-def get_upath_for_protocol(path: str | Path) -> UPath:
+def get_upath_for_protocol(path: str | Path, **kwargs) -> UPath:
     """Create UPath with protocol-specific configurations.
 
     If we access pointers on S3 and credentials are not found we assume
@@ -40,17 +42,23 @@ def get_upath_for_protocol(path: str | Path) -> UPath:
     ----------
     path: str | Path | UPath
         base file path to be normalized to UPath
+    **kwargs
+        additional storage options required for the file system backend.
 
     Returns
     -------
     UPath
         Instance of UPath.
     """
-    upath = UPath(path)
+    upath = UPath(path, **kwargs)
     if upath.protocol == "s3":
-        upath = UPath(path, anon=True, default_block_size=BLOCK_SIZE)
-    if upath.protocol in ("http", "https"):
         kwargs = {
+            "anon": True,
+            "default_block_size": BLOCK_SIZE,
+        } | kwargs
+        upath = UPath(path, **kwargs)
+    if upath.protocol in ("http", "https"):
+        kwargs = kwargs | {
             "block_size": BLOCK_SIZE,
             "client_kwargs": {"headers": {"User-Agent": f"hats/{version('hats')}"}},
         }

--- a/src/hats/io/validation.py
+++ b/src/hats/io/validation.py
@@ -9,6 +9,7 @@ import pyarrow.dataset as pds
 from upath import UPath
 
 from hats.catalog.catalog import Catalog
+from hats.catalog.catalog_collection import CatalogCollection
 from hats.catalog.dataset.collection_properties import CollectionProperties
 from hats.catalog.dataset.table_properties import TableProperties
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset
@@ -115,7 +116,9 @@ def is_valid_collection(
         return False
     if not strict:
         collection_properties = CollectionProperties.read_from_dir(pointer)
-        return is_valid_catalog(pointer / collection_properties.hats_primary_table_url)
+        return is_valid_catalog(
+            CatalogCollection.resolve_inner_path(pointer, collection_properties.hats_primary_table_url)
+        )
 
     # For catalog collections, we will confirm that all the member catalogs listed in the
     # collection properties exist and are valid, according to their expected types.

--- a/src/hats/loaders/read_hats.py
+++ b/src/hats/loaders/read_hats.py
@@ -74,7 +74,8 @@ def read_hats(
 def _load_collection(collection_path: UPath, read_moc: bool = True) -> CatalogCollection:
     collection_properties = CollectionProperties.read_from_dir(collection_path)
     main_catalog = _load_catalog(
-        collection_path / collection_properties.hats_primary_table_url, read_moc=read_moc
+        CatalogCollection.resolve_inner_path(collection_path, collection_properties.hats_primary_table_url),
+        read_moc=read_moc,
     )
     return CatalogCollection(collection_path, collection_properties, main_catalog)
 

--- a/src/hats/loaders/read_hats.py
+++ b/src/hats/loaders/read_hats.py
@@ -30,7 +30,11 @@ DATASET_TYPE_TO_CLASS = {
 
 
 def read_hats(
-    catalog_path: str | Path | UPath, *, single_catalog: bool | None = None, read_moc: bool = True
+    catalog_path: str | Path | UPath,
+    *,
+    single_catalog: bool | None = None,
+    read_moc: bool = True,
+    storage_options: dict | None = None,
 ) -> CatalogCollection | Dataset:
     """Reads a HATS Catalog from a HATS directory
 
@@ -46,6 +50,8 @@ def read_hats(
         If you happen to know that your catalog does not have a MOC (or if
         you know that your use case will not utilize a MOC), then you can
         skip the file read and memory load of the MOC.
+    storage_options: dict or None, default None
+        additional options for connecting to the catalog, or a collection's affiliated tables.
 
     Returns
     -------
@@ -59,25 +65,33 @@ def read_hats(
         from upath import UPath
         catalog = hats.read_hats(UPath(..., anon=True))
     """
-    path = file_io.get_upath(catalog_path)
+    if storage_options is None:
+        storage_options = {}
+    path = file_io.get_upath(catalog_path, **storage_options)
     if single_catalog is not None:
         if single_catalog:
             return _load_catalog(path, read_moc=read_moc)
-        return _load_collection(path, read_moc=read_moc)
+        return _load_collection(path, read_moc=read_moc, storage_options=storage_options)
     if (path / "hats.properties").exists() or (path / "properties").exists():
         return _load_catalog(path, read_moc=read_moc)
     if (path / "collection.properties").exists():
-        return _load_collection(path, read_moc=read_moc)
+        return _load_collection(path, read_moc=read_moc, storage_options=storage_options)
     raise FileNotFoundError(f"Failed to read HATS at location {catalog_path}")
 
 
-def _load_collection(collection_path: UPath, read_moc: bool = True) -> CatalogCollection:
+def _load_collection(
+    collection_path: UPath, read_moc: bool = True, storage_options: dict | None = None
+) -> CatalogCollection:
     collection_properties = CollectionProperties.read_from_dir(collection_path)
     main_catalog = _load_catalog(
-        CatalogCollection.resolve_inner_path(collection_path, collection_properties.hats_primary_table_url),
+        CatalogCollection.resolve_inner_path(
+            collection_path, collection_properties.hats_primary_table_url, storage_options=storage_options
+        ),
         read_moc=read_moc,
     )
-    return CatalogCollection(collection_path, collection_properties, main_catalog)
+    return CatalogCollection(
+        collection_path, collection_properties, main_catalog, storage_options=storage_options
+    )
 
 
 def _load_catalog(catalog_path: UPath, read_moc: bool = True) -> Dataset:

--- a/tests/hats/io/file_io/test_file_io.py
+++ b/tests/hats/io/file_io/test_file_io.py
@@ -176,9 +176,20 @@ def test_read_hats_with_http():
     assert upath_http.fs.client_kwargs["headers"]["User-Agent"].startswith("hats")
     assert not _parquet_precache_all_bytes(upath_http.fs)
 
-    upath_https = get_upath_for_protocol("https://catalog")
+    # Make sure we're not overriding any user-supplied User-Agent.
+    upath_https = get_upath_for_protocol("https://catalog", client_kwargs={"headers": {"User-Agent": "007"}})
+    assert upath_https.fs.block_size == 32 * 1024
+    assert upath_https.fs.client_kwargs["headers"]["User-Agent"] == "007"
+    assert not _parquet_precache_all_bytes(upath_https.fs)
+
+    # Make sure we're not overriding any other user-supplied connection parameters.
+    upath_https = get_upath_for_protocol(
+        "https://catalog", client_kwargs={"headers": {"other_header": "header_value"}, "method": "POST"}
+    )
     assert upath_https.fs.block_size == 32 * 1024
     assert upath_https.fs.client_kwargs["headers"]["User-Agent"].startswith("hats")
+    assert upath_https.fs.client_kwargs["headers"]["other_header"] == "header_value"
+    assert upath_https.fs.client_kwargs["method"] == "POST"
     assert not _parquet_precache_all_bytes(upath_https.fs)
 
     upath_http_full = get_upath_for_protocol("http://catalog.lsdb.org/hats/catalogs/gaia_dr3")


### PR DESCRIPTION
## Change Description

Part of https://github.com/astronomy-commons/hats/issues/673

Allow users to specify any additional storage options when opening a catalog.

These storage options are carried through the path creation, and the catalog collection holds on to the options for opening the sub-catalogs.