### PR TITLE
fix Deprecation Warning

### DIFF
--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -434,9 +434,13 @@ def generate_summary(
         # sets jinja_template as a file as a path
     match fmt:
         case "markdown":
-            tmpl_str = jinja2_template or importlib.resources.read_text(templates, md_tmpl)
+            tmpl_str = jinja2_template or importlib.resources.files(templates).joinpath(md_tmpl).read_text(
+                encoding="utf-8"
+            )
         case "html":
-            tmpl_str = jinja2_template or importlib.resources.read_text(templates, html_tmpl)
+            tmpl_str = jinja2_template or importlib.resources.files(templates).joinpath(html_tmpl).read_text(
+                encoding="utf-8"
+            )
         case None:
             tmpl_str = jinja2_template
         case _:

--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -434,13 +434,9 @@ def generate_summary(
         # sets jinja_template as a file as a path
     match fmt:
         case "markdown":
-            tmpl_str = jinja2_template or importlib.resources.files(templates).joinpath(md_tmpl).read_text(
-                encoding="utf-8"
-            )
+            tmpl_str = jinja2_template or importlib.resources.files(templates).joinpath(md_tmpl).read_text()
         case "html":
-            tmpl_str = jinja2_template or importlib.resources.files(templates).joinpath(html_tmpl).read_text(
-                encoding="utf-8"
-            )
+            tmpl_str = jinja2_template or importlib.resources.files(templates).joinpath(html_tmpl).read_text()
         case None:
             tmpl_str = jinja2_template
         case _:


### PR DESCRIPTION


Closes issue #708. 

## Solution Description

importlib resources read_text in summary_file.py is deprecated in Python 3.11+ versions, so I replaced it with importlib.resoures.files(...).joinpath(...).read_text(...)

People oftentimes run on different versions of Python, and it seems like importlib resources read_text has been undeprecated...


## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
