### PR TITLE
Add summary file generation support for AssociationCatalogs

### DIFF
--- a/src/hats/io/summary_file.py
+++ b/src/hats/io/summary_file.py
@@ -13,6 +13,7 @@ import pandas as pd
 from upath import UPath
 
 from hats.catalog import CollectionProperties
+from hats.catalog.association_catalog.association_catalog import AssociationCatalog
 from hats.catalog.catalog_collection import CatalogCollection
 from hats.catalog.dataset import Dataset
 from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset
@@ -26,6 +27,8 @@ from hats.loaders.read_hats import read_hats
 
 def _cone_code_example(column_table: pd.DataFrame, cat_props) -> dict | None:
     if "example" not in column_table:
+        return None
+    if cat_props.ra_column is None or cat_props.dec_column is None:
         return None
     ra = np.round(float(column_table.loc[cat_props.ra_column]["example"]))
     if ra >= 360.0:
@@ -287,7 +290,10 @@ def _get_example_frame(catalog: Dataset, rng: np.random.Generator) -> npd.Nested
     if not healpix_pixels:
         return None
     pixel = rng.choice(healpix_pixels)
-    return catalog.read_pixel_to_pandas(pixel)
+    try:
+        return catalog.read_pixel_to_pandas(pixel)
+    except FileNotFoundError:
+        return None
 
 
 def _get_example_row(catalog: HealpixDataset) -> npd.NestedFrame | None:
@@ -314,8 +320,12 @@ def _generate_sky_coverage_images(catalog, name: str | None = None):
     density_title = f"Angular density of catalog {name}" if name else None
     fig, _ = catalog.plot_pixels(plot_title=pixel_title)
     pixel_map_b64 = _fig_to_webp_base64(fig)
-    fig, _ = plot_density(catalog, norm=LogNorm(), edgecolors="face", plot_title=density_title)
-    density_map_b64 = _fig_to_webp_base64(fig)
+    density_map_b64 = None
+    try:
+        fig, _ = plot_density(catalog, norm=LogNorm(), edgecolors="face", plot_title=density_title)
+        density_map_b64 = _fig_to_webp_base64(fig)
+    except FileNotFoundError:
+        pass
     return pixel_map_b64, density_map_b64
 
 
@@ -425,6 +435,8 @@ def generate_summary(
         md_tmpl, html_tmpl = "margin_md_template.jinja2", "margin_html_template.jinja2"
     elif isinstance(catalog, IndexCatalog):
         md_tmpl, html_tmpl = "index_md_template.jinja2", "index_html_template.jinja2"
+    elif isinstance(catalog, AssociationCatalog):
+        md_tmpl, html_tmpl = "association_md_template.jinja2", "association_html_template.jinja2"
     else:
         md_tmpl, html_tmpl = "catalog_md_template.jinja2", "catalog_html_template.jinja2"
     env = jinja2.Environment(undefined=jinja2.StrictUndefined)
@@ -580,6 +592,11 @@ def write_catalog_summary_file(
     elif isinstance(catalog, Catalog):
         name = name or catalog.catalog_info.catalog_name
         description = description or f"This is the HATS catalog for {name}."
+    elif isinstance(catalog, AssociationCatalog):
+        name = name or catalog.catalog_info.catalog_name
+        primary = catalog.catalog_info.primary_catalog
+        join = catalog.catalog_info.join_catalog
+        description = description or f"This is the association catalog linking {primary} with {join}."
 
     content = generate_summary(
         catalog,

--- a/src/hats/io/templates/association_html_template.jinja2
+++ b/src/hats/io/templates/association_html_template.jinja2
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{name}} HATS Association Catalog</title>
+  <style>
+    body { font-family: sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; color: #222; }
+    h1, h2, h3 { border-bottom: 1px solid #ddd; padding-bottom: 0.3em; }
+    table { border-collapse: collapse; width: 100%; margin: 1em 0; display: block; overflow-x: auto; }
+    th, td { border: 1px solid #ddd; padding: 0.5em 0.75em; text-align: left; }
+    th { background: #f5f5f5; }
+    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 1em; border-radius: 4px; overflow-x: auto; }
+    code { font-family: monospace; background: #f3f3f3; padding: 0.1em 0.3em; border-radius: 3px; }
+    a { color: #0969da; }
+    img { max-width: 100%; display: block; margin: 1em 0; }
+    blockquote { border-left: 4px solid #ddd; margin: 1em 0; padding: 0.5em 1em; color: #555; background: #fafafa; }
+  </style>
+</head>
+<body>
+
+<h1>{{name}} HATS Association Catalog</h1>
+<blockquote><strong>&#x26a0; Note:</strong> This is auxiliary data. It is a cross-match join table linking two HATS catalogs and is not intended to be used as a standalone catalog.</blockquote>
+<p>{{description}}</p>
+
+<h3>Access the catalog</h3>
+<p>We recommend the use of the <a href="https://lsdb.io">LSDB</a> Python framework to access HATS catalogs.
+LSDB can be installed via <code>pip install lsdb</code> or <code>conda install conda-forge::lsdb</code>,
+see more details <a href="https://docs.lsdb.io/">in the docs</a>.
+The following code provides a minimal example of reading and joining this association catalog:</p>
+
+<pre><code>import lsdb
+
+primary = lsdb.open_catalog("{{ uri or '&lt;PATH&gt;' }}/../{{cat_props.primary_catalog}}")
+secondary = lsdb.open_catalog("{{ uri or '&lt;PATH&gt;' }}/../{{cat_props.join_catalog}}")
+
+result = primary.join(secondary, through="{{ uri or '&lt;PATH&gt;' }}")</code></pre>
+
+<p>See the <a href="https://docs.lsdb.io/en/latest/reference/api/lsdb.catalog.Catalog.join.html#lsdb.catalog.Catalog.join">LSDB join documentation</a> for more details.</p>
+
+<p>This catalog is represented as an <a href="https://arrow.apache.org/docs/python/dataset.html">Apache Parquet dataset</a> and can be accessed with a variety of tools, including <code>pandas</code>, <code>pyarrow</code>, <code>dask</code>, <code>Spark</code>, <code>DuckDB</code>.</p>
+
+{% if pixel_map_b64 %}
+<h2>Sky coverage</h2>
+<img src="data:image/webp;base64,{{pixel_map_b64}}" alt="Pixel Skymap">
+{% endif %}
+
+<h3>Association details</h3>
+<table>
+  <tr><th>Field</th><th>Value</th></tr>
+  <tr><td>Primary catalog</td><td><code>{{cat_props.primary_catalog}}</code></td></tr>
+  <tr><td>Primary join column</td><td><code>{{cat_props.primary_column}}</code></td></tr>
+  <tr><td>Join catalog</td><td><code>{{cat_props.join_catalog}}</code></td></tr>
+  <tr><td>Join column</td><td><code>{{cat_props.join_column}}</code></td></tr>
+  {%- if cat_props.assn_max_separation is not none %}
+  <tr><td>Max separation</td><td>{{ '%.2f' % cat_props.assn_max_separation }} arcseconds</td></tr>
+  {%- endif %}
+</table>
+
+<h3>File structure</h3>
+<p>This catalog is represented by the following files and directories:</p>
+<ul>
+  <li><a href="."><code>{{catalog_dir_name}}/</code></a> — association catalog directory
+    <ul>
+      <li><a href="dataset/"><code>dataset/</code></a> — Apache Parquet dataset directory
+        <ul><li>... parquet metadata and data files in sub directories ...</li></ul>
+      </li>
+      <li><a href="hats.properties"><code>hats.properties</code></a> — textual metadata file describing this association catalog</li>
+      {%- if has_partition_info %}
+      <li><a href="partition_info.csv"><code>partition_info.csv</code></a> — CSV file with a list of catalog HEALPix tiles</li>
+      {%- endif %}
+      {%- if cat_props.skymap_order %}
+      <li><a href="skymap.fits"><code>skymap.fits</code></a> — HEALPix skymap FITS file with row-counts per HEALPix tile of fixed order {{cat_props.skymap_order}}</li>
+      {%- endif %}
+    </ul>
+  </li>
+</ul>
+
+<h3>Catalog metadata</h3>
+<table>
+  <tr>{% for key in metadata_table.keys() %}<th>{{key}}</th>{% endfor %}</tr>
+  <tr>{% for value in metadata_table.values() %}<td>{{value}}</td>{% endfor %}</tr>
+</table>
+
+{% if not column_table.empty %}
+<h3>Association Catalog Columns</h3>
+<table>
+  <tr><th>Name</th>{% for col in column_table.index %}<th><code>{{col}}</code></th>{% endfor %}</tr>
+  <tr><th>Data Type</th>{% for value in column_table.dtype %}<td>{{value}}</td>{% endfor %}</tr>
+  {%- if "nested_into" in column_table %}
+  <tr><th>Nested?</th>{% for value in column_table.nested_into %}<td>{{ value or "—" }}</td>{% endfor %}</tr>
+  {%- endif %}
+  {%- if "rows" in column_table %}
+  <tr><th>Value count</th>{% for value in column_table.rows %}<td>{{ value }}</td>{% endfor %}</tr>
+  {%- endif %}
+  {%- if "nulls" in column_table %}
+  <tr><th>Null count</th>{% for value in column_table.nulls %}<td>{{ value }}</td>{% endfor %}</tr>
+  {%- endif %}
+  {%- if "example" in column_table %}
+  <tr><th>Example row</th>{% for value in column_table.example %}<td>{{ value }}</td>{% endfor %}</tr>
+  {%- endif %}
+  {%- if "min_value" in column_table %}
+  <tr><th>Minimum value</th>{% for value in column_table.min_value %}<td>{{ value }}</td>{% endfor %}</tr>
+  {%- endif %}
+  {%- if "max_value" in column_table %}
+  <tr><th>Maximum value</th>{% for value in column_table.max_value %}<td>{{ value }}</td>{% endfor %}</tr>
+  {%- endif %}
+</table>
+{% endif %}
+
+</body>
+</html>

--- a/src/hats/io/templates/association_md_template.jinja2
+++ b/src/hats/io/templates/association_md_template.jinja2
@@ -1,0 +1,100 @@
+{%- if huggingface_metadata %}
+---
+configs:
+- config_name: default
+  data_dir: dataset
+tags:
+- astronomy
+---
+{%- endif %}
+
+# {{name}} HATS Association Catalog
+
+> **Note:** This is auxiliary data. It is a cross-match join table linking two HATS catalogs and is not intended to be used as a standalone catalog.
+
+{{description}}
+
+### Access the catalog
+
+We recommend the use of the [LSDB](https://lsdb.io) Python framework to access HATS catalogs.
+LSDB can be installed via `pip install lsdb` or `conda install conda-forge::lsdb`,
+see more details [in the docs](https://docs.lsdb.io/).
+The following code provides a minimal example of reading and joining this association catalog:
+
+```python
+import lsdb
+
+primary = lsdb.open_catalog("{{ uri or '<PATH>' }}/../{{cat_props.primary_catalog}}")
+secondary = lsdb.open_catalog("{{ uri or '<PATH>' }}/../{{cat_props.join_catalog}}")
+
+result = primary.join(secondary, through="{{ uri or '<PATH>' }}")
+```
+
+See the [LSDB join documentation](https://docs.lsdb.io/en/latest/reference/api/lsdb.catalog.Catalog.join.html#lsdb.catalog.Catalog.join) for more details.
+
+This catalog is represented as an [Apache Parquet dataset](https://arrow.apache.org/docs/python/dataset.html) and can be accessed with a variety of tools, including `pandas`, `pyarrow`, `dask`, `Spark`, `DuckDB`.
+
+### Association details
+
+| Field | Value |
+| --- | --- |
+| **Primary catalog** | `{{cat_props.primary_catalog}}` |
+| **Primary join column** | `{{cat_props.primary_column}}` |
+| **Join catalog** | `{{cat_props.join_catalog}}` |
+| **Join column** | `{{cat_props.join_column}}` |
+{%- if cat_props.assn_max_separation is not none %}
+| **Max separation** | {{ '%.2f' % cat_props.assn_max_separation }} arcseconds |
+{%- endif %}
+
+### File structure
+
+This catalog is represented by the following files and directories:
+
+- [`{{catalog_dir_name}}/`](.) — association catalog directory
+  - [`dataset/`](dataset/) — Apache Parquet dataset directory
+    - ... parquet metadata and data files in sub directories ...
+  - [`hats.properties`](hats.properties) — textual metadata file describing this association catalog
+  {%- if has_partition_info %}
+  - [`partition_info.csv`](partition_info.csv) — CSV file with a list of catalog HEALPix tiles
+  {%- endif %}
+  {%- if cat_props.skymap_order %}
+  - [`skymap.fits`](skymap.fits) — HEALPix skymap FITS file with row-counts per HEALPix tile of fixed order {{cat_props.skymap_order}}
+  {%- endif %}
+
+### Catalog metadata
+
+|{%- for name in metadata_table.keys() %} **{{name}}** |{%- endfor %}
+|{%- for _ in metadata_table %} --- |{%- endfor %}
+|{%- for value in metadata_table.values() %} {{value}} |{%- endfor %}
+
+{% if not column_table.empty %}
+### Association Catalog Columns
+
+| **Name** | {% for col in column_table.index %} **`{{col}}`** |{% endfor %}
+| --- | {% for _ in column_table.index %} --- |{% endfor %}
+| **Data Type** | {% for value in column_table.dtype %} {{value}} |{% endfor %}
+{%- if "nested_into" in column_table %}
+| **Nested?** | {% for value in column_table.nested_into %} {{ value or "—" }} |{% endfor %}
+{%- endif %}
+{%- if "rows" in column_table %}
+| **Value count** | {% for value in column_table.rows %} {{ value }} |{% endfor %}
+{%- endif %}
+{%- if "nulls" in column_table %}
+| **Null count** | {% for value in column_table.nulls %} {{ value }} |{% endfor %}
+{%- endif %}
+{%- if "example" in column_table %}
+| **Example row** | {% for value in column_table.example %} {{ value }} |{% endfor %}
+{%- endif %}
+{%- if "min_value" in column_table %}
+| **Minimum value** | {% for value in column_table.min_value %} {{ value }} |{% endfor %}
+{%- endif %}
+{%- if "max_value" in column_table %}
+| **Maximum value** | {% for value in column_table.max_value %} {{ value }} |{% endfor %}
+{%- endif %}
+{% endif %}
+
+{% if pixel_map_b64 %}
+## Sky coverage
+
+![Pixel Skymap](data:image/webp;base64,{{pixel_map_b64}})
+{% endif %}

--- a/tests/hats/io/test_summary_file.py
+++ b/tests/hats/io/test_summary_file.py
@@ -526,6 +526,22 @@ def test_write_catalog_summary_file_contains_images(tmp_path, small_sky_collecti
     assert "![Density Skymap](data:image/webp;base64," in content
 
 
+def test_write_catalog_summary_file_association(tmp_path, association_catalog_path):
+    dest = tmp_path / association_catalog_path.name
+    shutil.copytree(association_catalog_path, dest)
+    output_path = write_catalog_summary_file(dest, fmt="markdown")
+    assert output_path.name == "README.md"
+    assert "HATS Association Catalog" in output_path.read_text()
+
+
+def test_write_catalog_summary_file_association_html(tmp_path, association_catalog_path):
+    dest = tmp_path / association_catalog_path.name
+    shutil.copytree(association_catalog_path, dest)
+    output_path = write_catalog_summary_file(dest, fmt="html")
+    assert output_path.name == "index.html"
+    assert "HATS Association Catalog" in output_path.read_text()
+
+
 def test_write_catalog_summary_file_margin(tmp_path, margin_catalog_path):
     dest = tmp_path / margin_catalog_path.name
     shutil.copytree(margin_catalog_path, dest)


### PR DESCRIPTION
Added supported in summary_file.py for association catalogs, and added the appropriate jinja2 file templates in html and md. Attached is what the template in html looks like right now: 

<img width="1066" height="1754" alt="image" src="https://github.com/user-attachments/assets/83d4a16f-eb1f-43cf-82d6-407fcd1db0be" />

Closes #709 



## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
