### PR TITLE
Optimize memory size partitioning

### DIFF
--- a/src/.pylintrc
+++ b/src/.pylintrc
@@ -62,7 +62,7 @@ ignore-patterns=_version.py
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=astropy.units
+ignored-modules=astropy.units,pyarrow.compute
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/src/hats/io/size_estimates.py
+++ b/src/hats/io/size_estimates.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.compute as pc
 from upath import UPath
 
 from hats.io import file_io
@@ -34,34 +35,127 @@ def estimate_dir_size(path: str | Path | UPath | None = None, *, divisor=1):
     return est_size
 
 
-def _item_mem_size(item):
-    """Return the memory size of a single scalar value, in bytes.
+def _is_fixed_width_arrow_type(arrow_type):
+    """Whether every value of the arrow type occupies the same number of bytes."""
+    return (
+        pa.types.is_integer(arrow_type)
+        or pa.types.is_floating(arrow_type)
+        or pa.types.is_boolean(arrow_type)
+        or pa.types.is_decimal(arrow_type)
+        or pa.types.is_temporal(arrow_type)
+        or pa.types.is_fixed_size_binary(arrow_type)
+    )
 
-    This is the per-element measurement shared by both the pandas and pyarrow
-    branches of ``get_mem_size_per_row``. By the time a value reaches this
-    function, it is already a native Python object: a pandas cell value (e.g.
-    int, float, str, or, for nested/list-valued columns, a ``np.ndarray``), or
-    the result of pyarrow's ``.as_py()``/``to_pylist()`` conversion (e.g. int,
-    float, str, bytes, list, dict).
+
+def _fixed_value_width(arrow_type):
+    """Bytes per value of a fixed-width arrow type. Bit-packed types (booleans)
+    are counted as one byte per value, matching their numpy/pandas representation."""
+    return max(1, arrow_type.bit_width // 8)
+
+
+def _string_like_offset_width(arrow_type):
+    """Offset-entry bytes per row for string/binary types, or None if not string-like."""
+    if pa.types.is_string(arrow_type) or pa.types.is_binary(arrow_type):
+        return 4
+    if pa.types.is_large_string(arrow_type) or pa.types.is_large_binary(arrow_type):
+        return 8
+    return None
+
+
+def _arrow_column_mem_sizes(column):
+    """Estimated per-row loaded-memory bytes for a pyarrow column.
+
+    Arrow stores variable-length columns as one flat values buffer plus an
+    offsets buffer, so each row's share of the loaded buffers can be read from
+    the offsets (``pc.list_value_length`` / ``pc.binary_length``) without
+    converting any values to Python objects. Summed over the rows of a
+    partition, these shares reproduce the partition's buffer sizes.
 
     Args:
-        item: a single cell value, as described above.
+        column (pa.Array or pa.ChunkedArray): the column to measure.
+
+    Returns:
+        np.ndarray: per-row memory sizes, in bytes.
+    """
+    column_type = column.type
+    num_rows = len(column)
+
+    if _is_fixed_width_arrow_type(column_type):
+        return np.full(num_rows, _fixed_value_width(column_type), dtype=np.int64)
+
+    offset_width = _string_like_offset_width(column_type)
+    if offset_width is not None:
+        # binary_length counts the data bytes of each value (nulls hold no data,
+        # but still occupy an offset entry).
+        data_bytes = pc.fill_null(pc.binary_length(column), 0)
+        return data_bytes.to_numpy(zero_copy_only=False).astype(np.int64) + offset_width
+
+    if pa.types.is_list(column_type) or pa.types.is_large_list(column_type):
+        offset_width = 8 if pa.types.is_large_list(column_type) else 4
+        lengths = pc.fill_null(pc.list_value_length(column), 0)
+        lengths = lengths.to_numpy(zero_copy_only=False).astype(np.int64)
+        element_type = column_type.value_type
+        if _is_fixed_width_arrow_type(element_type):
+            return lengths * _fixed_value_width(element_type) + offset_width
+        # Variable-width elements (e.g. list<string>): attribute the flattened
+        # elements' total buffer size uniformly per element.
+        flattened = pc.list_flatten(column)
+        bytes_per_element = flattened.nbytes / len(flattened) if len(flattened) else 0
+        return (lengths * bytes_per_element).astype(np.int64) + offset_width
+
+    if pa.types.is_struct(column_type):
+        # A struct row (e.g. a nested column's row) costs the sum of its fields.
+        sizes = np.zeros(num_rows, dtype=np.int64)
+        for field_index in range(column_type.num_fields):
+            sizes += _arrow_column_mem_sizes(pc.struct_field(column, field_index))
+        return sizes
+
+    # Types outside the model (dictionary, union, ...): attribute the column's
+    # total buffer size uniformly across rows.
+    bytes_per_row = column.nbytes // num_rows if num_rows else 0
+    return np.full(num_rows, bytes_per_row, dtype=np.int64)
+
+
+def _item_mem_size(item):
+    """Return the loaded-memory size of a single cell value, in bytes.
+
+    This is the fallback measurement for pandas columns that cannot be
+    represented in arrow (e.g. object columns with mixed content). Sizes are
+    best-effort approximations of the loaded footprint.
+
+    Args:
+        item: a single cell value.
 
     Returns:
         int: the estimated memory size of ``item``, in bytes.
     """
     if isinstance(item, np.ndarray):
-        # np.ndarray is a special case: sys.getsizeof() on an ndarray only
-        # reports the object's own overhead, not the underlying data buffer it
-        # points to, so we add the buffer size (nbytes) explicitly.
-        return item.nbytes + sys.getsizeof(item)  # object data + object overhead
-    # For every other type (int, float, str, bytes, list, dict, etc.) sys.getsizeof
-    # already accounts for the full memory footprint of the object.
+        # The loaded data is the array's buffer; the Python object wrapper is
+        # not counted.
+        return item.nbytes
+    # For other types, sys.getsizeof is the best available approximation.
     return sys.getsizeof(item)
 
 
 def get_mem_size_per_row(data, cols=None):
-    """Given a 2D array of data, return a list of memory sizes for each row in the chunk.
+    """Estimate the memory footprint of each row when the data is loaded.
+
+    Sizes model the columnar (arrow/numpy) representation the data occupies
+    once loaded into memory: each row costs its slice of the column buffers.
+
+    - fixed-width values (ints, floats, datetimes, ...): the value's byte
+      width, with bit-packed types (booleans) counted as one byte per value;
+    - strings and binary: the value's data bytes, plus one offset entry;
+    - lists: element count x element byte width (variable-width elements are
+      attributed their column-wide average), plus one offset entry;
+    - structs (e.g. nested columns): the sum of their fields' contributions.
+
+    Column types outside this model have their total buffer size attributed
+    uniformly across rows, and null bitmaps are not counted. Per-object Python
+    overheads are deliberately excluded: they describe the cost of
+    materializing rows as Python objects, not of loading the data. Summing a
+    group of rows' sizes therefore estimates the memory needed to load that
+    group as a partition.
 
     Args:
         data (pd.DataFrame or pa.Table): the data chunk to measure
@@ -75,41 +169,27 @@ def get_mem_size_per_row(data, cols=None):
         if cols is not None:
             data = data[cols]
 
-        # Each row is conceptually a tuple of its column values, and sys.getsizeof()
-        # of a tuple depends only on how many elements it holds, not on what those
-        # elements are. So this overhead is the same for every row, and we only need
-        # to compute it once here instead of re-measuring a row tuple for every row.
-        row_overhead = sys.getsizeof(tuple([None] * len(data.columns)))
-
-        # Start every row's running total at that shared per-row overhead.
-        mem_sizes = pd.Series(row_overhead, index=data.index)
-
-        # Add each column's contribution to every row's total, one column at a time.
-        # Series.map() applies _item_mem_size to every value in the column in one
-        # vectorized pass, which is much faster than rebuilding a Python tuple for
-        # every row via itertuples() and looping over its items by hand.
+        mem_sizes = np.zeros(len(data), dtype=np.int64)
         for column in data.columns:
-            mem_sizes += data[column].map(_item_mem_size)
-
-        # Series.tolist() converts numpy scalar types (e.g. np.int64) in the Series
-        # back to plain Python ints, matching this function's documented return type.
-        mem_sizes = mem_sizes.tolist()
+            series = data[column]
+            try:
+                # Convert to arrow (cheap for numeric and arrow-backed columns) so
+                # pandas and pyarrow inputs are measured with the same model.
+                arrow_column = pa.array(series, from_pandas=True)
+            except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError, ValueError):
+                # Columns arrow can't represent: best-effort per-value measurement.
+                mem_sizes += np.fromiter((_item_mem_size(item) for item in series), np.int64, len(series))
+                continue
+            mem_sizes += _arrow_column_mem_sizes(arrow_column)
     elif isinstance(data, pa.Table):
         if cols is not None:
             data = data.select(cols)
 
-        # Mirror the pandas row overhead above: pyarrow's per-row overhead doesn't
-        # depend on row content either, so it's a constant added to every row.
-        row_overhead = sys.getsizeof(0)
-        mem_sizes = [row_overhead] * data.num_rows
-
-        # Walk one column at a time. column.to_pylist() converts the whole column to
-        # native Python values in a single fast (C-level) pass, which avoids the
-        # overhead of indexing into the column with column[row_index] (which boxes
-        # each value as a pa.Scalar) once per cell.
+        mem_sizes = np.zeros(data.num_rows, dtype=np.int64)
         for column in data.itercolumns():
-            for row_index, item in enumerate(column.to_pylist()):
-                mem_sizes[row_index] += _item_mem_size(item)
+            mem_sizes += _arrow_column_mem_sizes(column)
     else:
         raise NotImplementedError(f"Unsupported data type {type(data)} for memory size calculation")
-    return mem_sizes
+
+    # Back to plain Python ints, matching this function's documented return type.
+    return mem_sizes.tolist()

--- a/src/hats/io/size_estimates.py
+++ b/src/hats/io/size_estimates.py
@@ -48,9 +48,27 @@ def _is_fixed_width_arrow_type(arrow_type):
 
 
 def _fixed_value_width(arrow_type):
-    """Bytes per value of a fixed-width arrow type. Bit-packed types (booleans)
-    are counted as one byte per value, matching their numpy/pandas representation."""
-    return max(1, arrow_type.bit_width // 8)
+    """Bytes per value of a fixed-width arrow type, as stored in loaded arrow
+    buffers. Bit-packed types (booleans) cost their true bit width — 1/8 byte
+    per value — so the returned width may be fractional."""
+    if pa.types.is_fixed_size_binary(arrow_type):
+        return float(arrow_type.byte_width)
+    return arrow_type.bit_width / 8
+
+
+def _bitmap_share(array):
+    """Per-row share of an array's validity bitmap, in bytes (one bit per row
+    when the bitmap is materialized). The buffer's presence is what counts, not
+    the null count: arrow allocates it when nulls are present, but readers may
+    also materialize an all-valid bitmap for nullable columns (e.g. the parquet
+    reader), and ``Table.nbytes`` includes it either way."""
+    num_rows = len(array)
+    if num_rows == 0:
+        return 0.0
+    chunks = array.chunks if isinstance(array, pa.ChunkedArray) else [array]
+    # buffers()[0] is the array's own validity bitmap (children's buffers follow).
+    rows_with_bitmap = sum(len(chunk) for chunk in chunks if chunk.buffers()[0] is not None)
+    return 0.125 * rows_with_bitmap / num_rows
 
 
 def _string_like_offset_width(arrow_type):
@@ -69,51 +87,56 @@ def _arrow_column_mem_sizes(column):
     offsets buffer, so each row's share of the loaded buffers can be read from
     the offsets (``pc.list_value_length`` / ``pc.binary_length``) without
     converting any values to Python objects. Summed over the rows of a
-    partition, these shares reproduce the partition's buffer sizes.
+    partition, these shares reproduce the partition's loaded buffer sizes
+    (``Table.nbytes``), including validity bitmaps where present. Per-row sizes
+    may be fractional (bit-packed booleans, bitmap bits).
 
     Args:
         column (pa.Array or pa.ChunkedArray): the column to measure.
 
     Returns:
-        np.ndarray: per-row memory sizes, in bytes.
+        np.ndarray: per-row memory sizes, in (possibly fractional) bytes.
     """
     column_type = column.type
     num_rows = len(column)
 
     if _is_fixed_width_arrow_type(column_type):
-        return np.full(num_rows, _fixed_value_width(column_type), dtype=np.int64)
+        return np.full(num_rows, _fixed_value_width(column_type) + _bitmap_share(column))
 
     offset_width = _string_like_offset_width(column_type)
     if offset_width is not None:
         # binary_length counts the data bytes of each value (nulls hold no data,
         # but still occupy an offset entry).
         data_bytes = pc.fill_null(pc.binary_length(column), 0)
-        return data_bytes.to_numpy(zero_copy_only=False).astype(np.int64) + offset_width
+        data_bytes = data_bytes.to_numpy(zero_copy_only=False).astype(np.float64)
+        return data_bytes + offset_width + _bitmap_share(column)
 
     if pa.types.is_list(column_type) or pa.types.is_large_list(column_type):
         offset_width = 8 if pa.types.is_large_list(column_type) else 4
         lengths = pc.fill_null(pc.list_value_length(column), 0)
-        lengths = lengths.to_numpy(zero_copy_only=False).astype(np.int64)
+        lengths = lengths.to_numpy(zero_copy_only=False).astype(np.float64)
+        per_row_overhead = offset_width + _bitmap_share(column)
+        flattened = pc.list_flatten(column)
         element_type = column_type.value_type
         if _is_fixed_width_arrow_type(element_type):
-            return lengths * _fixed_value_width(element_type) + offset_width
+            bytes_per_element = _fixed_value_width(element_type) + _bitmap_share(flattened)
+            return lengths * bytes_per_element + per_row_overhead
         # Variable-width elements (e.g. list<string>): attribute the flattened
         # elements' total buffer size uniformly per element.
-        flattened = pc.list_flatten(column)
         bytes_per_element = flattened.nbytes / len(flattened) if len(flattened) else 0
-        return (lengths * bytes_per_element).astype(np.int64) + offset_width
+        return lengths * bytes_per_element + per_row_overhead
 
     if pa.types.is_struct(column_type):
         # A struct row (e.g. a nested column's row) costs the sum of its fields.
-        sizes = np.zeros(num_rows, dtype=np.int64)
+        sizes = np.full(num_rows, _bitmap_share(column))
         for field_index in range(column_type.num_fields):
             sizes += _arrow_column_mem_sizes(pc.struct_field(column, field_index))
         return sizes
 
     # Types outside the model (dictionary, union, ...): attribute the column's
     # total buffer size uniformly across rows.
-    bytes_per_row = column.nbytes // num_rows if num_rows else 0
-    return np.full(num_rows, bytes_per_row, dtype=np.int64)
+    bytes_per_row = column.nbytes / num_rows if num_rows else 0.0
+    return np.full(num_rows, bytes_per_row)
 
 
 def _item_mem_size(item):
@@ -140,22 +163,25 @@ def _item_mem_size(item):
 def get_mem_size_per_row(data, cols=None):
     """Estimate the memory footprint of each row when the data is loaded.
 
-    Sizes model the columnar (arrow/numpy) representation the data occupies
-    once loaded into memory: each row costs its slice of the column buffers.
+    Sizes model the columnar arrow representation the data occupies once loaded
+    into memory (i.e. ``Table.nbytes``): each row costs its slice of the loaded
+    column buffers.
 
     - fixed-width values (ints, floats, datetimes, ...): the value's byte
-      width, with bit-packed types (booleans) counted as one byte per value;
+      width, with bit-packed types (booleans) counted at their true bit width
+      (1/8 byte per value);
     - strings and binary: the value's data bytes, plus one offset entry;
     - lists: element count x element byte width (variable-width elements are
       attributed their column-wide average), plus one offset entry;
-    - structs (e.g. nested columns): the sum of their fields' contributions.
+    - structs (e.g. nested columns): the sum of their fields' contributions;
+    - validity bitmaps: one bit per row/element, counted when the array holds
+      nulls (arrow only materializes the bitmap then).
 
     Column types outside this model have their total buffer size attributed
-    uniformly across rows, and null bitmaps are not counted. Per-object Python
-    overheads are deliberately excluded: they describe the cost of
-    materializing rows as Python objects, not of loading the data. Summing a
-    group of rows' sizes therefore estimates the memory needed to load that
-    group as a partition.
+    uniformly across rows. Per-object Python overheads are deliberately
+    excluded: they describe the cost of materializing rows as Python objects,
+    not of loading the data. Summing a group of rows' sizes therefore estimates
+    the memory needed to load that group as a partition.
 
     Args:
         data (pd.DataFrame or pa.Table): the data chunk to measure
@@ -163,13 +189,14 @@ def get_mem_size_per_row(data, cols=None):
             per-row size calculation
 
     Returns:
-        list[int]: list of memory sizes for each row in the chunk
+        list[float]: list of memory sizes for each row in the chunk. Values may
+        be fractional (bit-packed booleans, bitmap bits); sum before rounding.
     """
     if isinstance(data, pd.DataFrame):
         if cols is not None:
             data = data[cols]
 
-        mem_sizes = np.zeros(len(data), dtype=np.int64)
+        mem_sizes = np.zeros(len(data), dtype=np.float64)
         for column in data.columns:
             series = data[column]
             try:
@@ -178,18 +205,20 @@ def get_mem_size_per_row(data, cols=None):
                 arrow_column = pa.array(series, from_pandas=True)
             except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError, ValueError):
                 # Columns arrow can't represent: best-effort per-value measurement.
-                mem_sizes += np.fromiter((_item_mem_size(item) for item in series), np.int64, len(series))
+                mem_sizes += np.fromiter(
+                    (_item_mem_size(item) for item in series), np.float64, len(series)
+                )
                 continue
             mem_sizes += _arrow_column_mem_sizes(arrow_column)
     elif isinstance(data, pa.Table):
         if cols is not None:
             data = data.select(cols)
 
-        mem_sizes = np.zeros(data.num_rows, dtype=np.int64)
+        mem_sizes = np.zeros(data.num_rows, dtype=np.float64)
         for column in data.itercolumns():
             mem_sizes += _arrow_column_mem_sizes(column)
     else:
         raise NotImplementedError(f"Unsupported data type {type(data)} for memory size calculation")
 
-    # Back to plain Python ints, matching this function's documented return type.
+    # Back to plain Python floats, matching this function's documented return type.
     return mem_sizes.tolist()

--- a/src/hats/io/size_estimates.py
+++ b/src/hats/io/size_estimates.py
@@ -34,52 +34,30 @@ def estimate_dir_size(path: str | Path | UPath | None = None, *, divisor=1):
     return est_size
 
 
-def _get_row_mem_size_data_frame(row):
-    """Given a pandas dataframe row (as a tuple), return the memory size of that row.
+def _item_mem_size(item):
+    """Return the memory size of a single scalar value, in bytes.
+
+    This is the per-element measurement shared by both the pandas and pyarrow
+    branches of ``get_mem_size_per_row``. By the time a value reaches this
+    function, it is already a native Python object: a pandas cell value (e.g.
+    int, float, str, or, for nested/list-valued columns, a ``np.ndarray``), or
+    the result of pyarrow's ``.as_py()``/``to_pylist()`` conversion (e.g. int,
+    float, str, bytes, list, dict).
 
     Args:
-        row (tuple): the row from the dataframe
+        item: a single cell value, as described above.
 
     Returns:
-        int: the memory size of the row in bytes
+        int: the estimated memory size of ``item``, in bytes.
     """
-    total = 0
-
-    # Add the memory overhead of the row object itself.
-    total += sys.getsizeof(row)
-
-    # Then add the size of each item in the row.
-    for item in row:
-        if isinstance(item, np.ndarray):
-            total += item.nbytes + sys.getsizeof(item)  # object data + object overhead
-        else:
-            total += sys.getsizeof(item)
-    return total
-
-
-def _get_row_mem_size_pa_table(table, row_index):
-    """Given a pyarrow table and a row index, return the memory size of that row.
-
-    Args:
-        table (pa.Table): the pyarrow table
-        row_index (int): the index of the row to measure
-
-    Returns:
-        int: the memory size of the row in bytes
-    """
-    total = 0
-
-    # Add the memory overhead of the row object itself.
-    total += sys.getsizeof(row_index)
-
-    # Then add the size of each item in the row.
-    for column in table.itercolumns():
-        item = column[row_index]
-        if isinstance(item, np.ndarray):
-            total += item.nbytes + sys.getsizeof(item)  # object data + object overhead
-        else:
-            total += sys.getsizeof(item.as_py())
-    return total
+    if isinstance(item, np.ndarray):
+        # np.ndarray is a special case: sys.getsizeof() on an ndarray only
+        # reports the object's own overhead, not the underlying data buffer it
+        # points to, so we add the buffer size (nbytes) explicitly.
+        return item.nbytes + sys.getsizeof(item)  # object data + object overhead
+    # For every other type (int, float, str, bytes, list, dict, etc.) sys.getsizeof
+    # already accounts for the full memory footprint of the object.
+    return sys.getsizeof(item)
 
 
 def get_mem_size_per_row(data, cols=None):
@@ -96,11 +74,42 @@ def get_mem_size_per_row(data, cols=None):
     if isinstance(data, pd.DataFrame):
         if cols is not None:
             data = data[cols]
-        mem_sizes = [_get_row_mem_size_data_frame(row) for row in data.itertuples(index=False, name=None)]
+
+        # Each row is conceptually a tuple of its column values, and sys.getsizeof()
+        # of a tuple depends only on how many elements it holds, not on what those
+        # elements are. So this overhead is the same for every row, and we only need
+        # to compute it once here instead of re-measuring a row tuple for every row.
+        row_overhead = sys.getsizeof(tuple([None] * len(data.columns)))
+
+        # Start every row's running total at that shared per-row overhead.
+        mem_sizes = pd.Series(row_overhead, index=data.index)
+
+        # Add each column's contribution to every row's total, one column at a time.
+        # Series.map() applies _item_mem_size to every value in the column in one
+        # vectorized pass, which is much faster than rebuilding a Python tuple for
+        # every row via itertuples() and looping over its items by hand.
+        for column in data.columns:
+            mem_sizes += data[column].map(_item_mem_size)
+
+        # Series.tolist() converts numpy scalar types (e.g. np.int64) in the Series
+        # back to plain Python ints, matching this function's documented return type.
+        mem_sizes = mem_sizes.tolist()
     elif isinstance(data, pa.Table):
         if cols is not None:
             data = data.select(cols)
-        mem_sizes = [_get_row_mem_size_pa_table(data, i) for i in range(data.num_rows)]
+
+        # Mirror the pandas row overhead above: pyarrow's per-row overhead doesn't
+        # depend on row content either, so it's a constant added to every row.
+        row_overhead = sys.getsizeof(0)
+        mem_sizes = [row_overhead] * data.num_rows
+
+        # Walk one column at a time. column.to_pylist() converts the whole column to
+        # native Python values in a single fast (C-level) pass, which avoids the
+        # overhead of indexing into the column with column[row_index] (which boxes
+        # each value as a pa.Scalar) once per cell.
+        for column in data.itercolumns():
+            for row_index, item in enumerate(column.to_pylist()):
+                mem_sizes[row_index] += _item_mem_size(item)
     else:
         raise NotImplementedError(f"Unsupported data type {type(data)} for memory size calculation")
     return mem_sizes

--- a/src/hats/io/size_estimates.py
+++ b/src/hats/io/size_estimates.py
@@ -82,18 +82,24 @@ def _get_row_mem_size_pa_table(table, row_index):
     return total
 
 
-def get_mem_size_per_row(data):
+def get_mem_size_per_row(data, cols=None):
     """Given a 2D array of data, return a list of memory sizes for each row in the chunk.
 
     Args:
         data (pd.DataFrame or pa.Table): the data chunk to measure
+        cols (list[str] or None): if provided, only these columns are included in the
+            per-row size calculation
 
     Returns:
         list[int]: list of memory sizes for each row in the chunk
     """
     if isinstance(data, pd.DataFrame):
+        if cols is not None:
+            data = data[cols]
         mem_sizes = [_get_row_mem_size_data_frame(row) for row in data.itertuples(index=False, name=None)]
     elif isinstance(data, pa.Table):
+        if cols is not None:
+            data = data.select(cols)
         mem_sizes = [_get_row_mem_size_pa_table(data, i) for i in range(data.num_rows)]
     else:
         raise NotImplementedError(f"Unsupported data type {type(data)} for memory size calculation")

--- a/src/hats/io/size_estimates.py
+++ b/src/hats/io/size_estimates.py
@@ -156,6 +156,11 @@ def _item_mem_size(item):
         # The loaded data is the array's buffer; the Python object wrapper is
         # not counted.
         return item.nbytes
+    if isinstance(item, np.generic):
+        # A numpy scalar (e.g. a structured np.void record cell that arrow could
+        # not convert): its buffer is itemsize bytes. sys.getsizeof would report
+        # the Python wrapper's overhead instead, which for np.void overcounts.
+        return item.itemsize
     # For other types, sys.getsizeof is the best available approximation.
     return sys.getsizeof(item)
 
@@ -205,9 +210,7 @@ def get_mem_size_per_row(data, cols=None):
                 arrow_column = pa.array(series, from_pandas=True)
             except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError, ValueError):
                 # Columns arrow can't represent: best-effort per-value measurement.
-                mem_sizes += np.fromiter(
-                    (_item_mem_size(item) for item in series), np.float64, len(series)
-                )
+                mem_sizes += np.fromiter((_item_mem_size(item) for item in series), np.float64, len(series))
                 continue
             mem_sizes += _arrow_column_mem_sizes(arrow_column)
     elif isinstance(data, pa.Table):

--- a/tests/hats/catalog/dataset/test_collection_properties.py
+++ b/tests/hats/catalog/dataset/test_collection_properties.py
@@ -32,9 +32,7 @@ def test_collection_properties_string():
     )
 
     ## str representation should not include additional properties.
-    assert (
-        str(expected_properties)
-        == """  name small_sky_01
+    assert str(expected_properties) == """  name small_sky_01
   hats_primary_table_url small_sky_order1
 """
     )

--- a/tests/hats/catalog/dataset/test_collection_properties.py
+++ b/tests/hats/catalog/dataset/test_collection_properties.py
@@ -35,7 +35,6 @@ def test_collection_properties_string():
     assert str(expected_properties) == """  name small_sky_01
   hats_primary_table_url small_sky_order1
 """
-    )
 
 
 def test_read_collection_list_parse(tmp_path):

--- a/tests/hats/catalog/dataset/test_collection_properties.py
+++ b/tests/hats/catalog/dataset/test_collection_properties.py
@@ -32,9 +32,12 @@ def test_collection_properties_string():
     )
 
     ## str representation should not include additional properties.
-    assert str(expected_properties) == """  name small_sky_01
+    assert (
+        str(expected_properties)
+        == """  name small_sky_01
   hats_primary_table_url small_sky_order1
 """
+    )
 
 
 def test_read_collection_list_parse(tmp_path):

--- a/tests/hats/io/test_size_estimates.py
+++ b/tests/hats/io/test_size_estimates.py
@@ -37,9 +37,7 @@ def test_estimate_dir_size_edge(tmp_path):
 def test_get_mem_size_per_row_pandas(small_sky_dir):
     small_sky_catalog = read_hats(small_sky_dir)
 
-    single_pixel_df = small_sky_catalog.read_pixel_to_pandas(
-        small_sky_catalog.get_healpix_pixels()[0]
-    )
+    single_pixel_df = small_sky_catalog.read_pixel_to_pandas(small_sky_catalog.get_healpix_pixels()[0])
     mem_sizes = get_mem_size_per_row(single_pixel_df)
     assert len(mem_sizes) == len(single_pixel_df)
 
@@ -67,9 +65,7 @@ def test_get_mem_size_per_row_pyarrow(small_sky_dir):
 def test_get_mem_size_per_row_pandas_nested(small_sky_nested_dir):
     small_sky_catalog = read_hats(small_sky_nested_dir)
 
-    single_pixel_df = small_sky_catalog.read_pixel_to_pandas(
-        small_sky_catalog.get_healpix_pixels()[0]
-    )
+    single_pixel_df = small_sky_catalog.read_pixel_to_pandas(small_sky_catalog.get_healpix_pixels()[0])
     mem_sizes = get_mem_size_per_row(single_pixel_df)
     assert len(mem_sizes) == len(single_pixel_df)
 
@@ -144,9 +140,7 @@ def test_get_mem_size_per_row_mixed_frame():
     assert len(mem_sizes_table_small) == 10
     assert all(isinstance(size, float) and size > 0 for size in mem_sizes_table_small)
     # Each entry in mem_sizes_table should be > corresponding entry in mem_sizes_table_small
-    assert all(
-        m > s for m, s in zip(mem_sizes_table, mem_sizes_table_small, strict=True)
-    )
+    assert all(m > s for m, s in zip(mem_sizes_table, mem_sizes_table_small, strict=True))
 
 
 def test_get_mem_size_per_row_nested_frame():
@@ -221,17 +215,13 @@ def test_get_mem_size_per_row_fixed_and_string_columns():
 
     # Fixed-size binary: every value costs its declared byte width (here 4); no
     # nulls, so no bitmap share.
-    fixed_binary = get_mem_size_per_row(
-        pa.table({"fb": pa.array([b"abcd", b"efgh", b"ijkl"], pa.binary(4))})
-    )
+    fixed_binary = get_mem_size_per_row(pa.table({"fb": pa.array([b"abcd", b"efgh", b"ijkl"], pa.binary(4))}))
     assert fixed_binary == [4.0, 4.0, 4.0]
     assert all(isinstance(size, float) for size in fixed_binary)
 
     # Large string: 8-byte offset entries instead of 4; no nulls, so no bitmap.
     # "ab" = 2 data bytes + 8; "cde" = 3 + 8.
-    large_string = get_mem_size_per_row(
-        pa.table({"name": pa.array(["ab", "cde"], pa.large_string())})
-    )
+    large_string = get_mem_size_per_row(pa.table({"name": pa.array(["ab", "cde"], pa.large_string())}))
     assert large_string == [10.0, 11.0]
     assert all(isinstance(size, float) for size in large_string)
 
@@ -244,9 +234,7 @@ def test_get_mem_size_per_row_list_columns():
     bitmap = 0.125
     lightcurves = [[10.1, 10.3, 9.8], [], None, [4.2] * 100]
     for list_type, offset_width in [(pa.list_, 4), (pa.large_list, 8)]:
-        table = pa.table(
-            {"lightcurve": pa.array(lightcurves, type=list_type(pa.float64()))}
-        )
+        table = pa.table({"lightcurve": pa.array(lightcurves, type=list_type(pa.float64()))})
         # Null rows hold no data but still occupy an offset entry.
         assert get_mem_size_per_row(table) == [
             3 * 8 + offset_width + bitmap,
@@ -317,14 +305,9 @@ def test_get_mem_size_per_row_pandas_non_arrow_columns():
     assert get_mem_size_per_row(frame) == [16.0, 32.0]
 
     # Arbitrary Python objects (neither ndarray nor numpy scalar): sys.getsizeof.
-    class Opaque:
-        pass
-
-    opaque = [Opaque(), Opaque()]
+    opaque = [object(), object()]
     frame = pd.DataFrame({"obj": pd.Series(opaque, dtype=object)})
-    assert get_mem_size_per_row(frame) == [
-        float(sys.getsizeof(cell)) for cell in opaque
-    ]
+    assert get_mem_size_per_row(frame) == [float(sys.getsizeof(cell)) for cell in opaque]
 
 
 def test_get_mem_size_per_row_pandas_pyarrow_equivalence_and_cols():
@@ -363,9 +346,7 @@ def test_get_mem_size_per_row_pandas_pyarrow_equivalence_and_cols():
     )
     selected = get_mem_size_per_row(frame, cols=["id", "ra"])
     assert selected == get_mem_size_per_row(frame[["id", "ra"]])
-    assert all(
-        s < full for s, full in zip(selected, get_mem_size_per_row(frame), strict=True)
-    )
+    assert all(s < full for s, full in zip(selected, get_mem_size_per_row(frame), strict=True))
 
     table = pa.table(
         {
@@ -376,9 +357,7 @@ def test_get_mem_size_per_row_pandas_pyarrow_equivalence_and_cols():
     )
     selected = get_mem_size_per_row(table, cols=["id", "ra"])
     assert selected == get_mem_size_per_row(table.select(["id", "ra"]))
-    assert all(
-        s < full for s, full in zip(selected, get_mem_size_per_row(table), strict=True)
-    )
+    assert all(s < full for s, full in zip(selected, get_mem_size_per_row(table), strict=True))
 
 
 def test_get_mem_size_per_row_pyarrow_empty_fixed_width():

--- a/tests/hats/io/test_size_estimates.py
+++ b/tests/hats/io/test_size_estimates.py
@@ -242,7 +242,11 @@ def test_get_mem_size_per_row_pyarrow_strings_and_fixed_widths():
 
     # id: 8 each; flag: 1/8 each; name: data bytes + 4-byte offset entry + 1/8
     # bitmap, where "ééé" is 6 UTF-8 bytes and the null row holds no data.
-    assert mem_sizes == [8 + 0.125 + (4 + 4 + 0.125), 8 + 0.125 + (0 + 4 + 0.125), 8 + 0.125 + (6 + 4 + 0.125)]
+    assert mem_sizes == [
+        8 + 0.125 + (4 + 4 + 0.125),
+        8 + 0.125 + (0 + 4 + 0.125),
+        8 + 0.125 + (6 + 4 + 0.125),
+    ]
 
 
 def test_get_mem_size_per_row_pyarrow_struct():
@@ -279,3 +283,19 @@ def test_get_mem_size_per_row_pandas_matches_pyarrow():
     )
 
     assert get_mem_size_per_row(frame) == get_mem_size_per_row(table)
+
+
+def test_get_mem_size_per_row_pandas_numpy_scalar_cells():
+    """An object column of numpy scalar cells (e.g. structured np.void records)
+    cannot be converted to arrow, so it falls back to per-item measurement. The
+    cell is sized by its buffer (itemsize), not the Python wrapper's overhead."""
+    record_type = np.dtype([("x", np.float64), ("y", np.float64)])
+    records = np.array([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dtype=record_type)
+    # Each cell is a np.void scalar; a DataFrame keeps them as an object column.
+    frame = pd.DataFrame({"record": pd.Series(list(records), dtype=object)})
+
+    mem_sizes = get_mem_size_per_row(frame)
+
+    # Two float64 fields => 16 bytes per record, regardless of Python overhead.
+    assert mem_sizes == [16.0, 16.0, 16.0]
+    assert all(isinstance(size, float) for size in mem_sizes)

--- a/tests/hats/io/test_size_estimates.py
+++ b/tests/hats/io/test_size_estimates.py
@@ -11,10 +11,6 @@ from hats.io.file_io import read_parquet_file
 from hats.io.paths import pixel_catalog_file
 from hats.io.size_estimates import estimate_dir_size, get_mem_size_per_row
 
-# ---------------------------------------------------------------------------
-# estimate_dir_size
-# ---------------------------------------------------------------------------
-
 
 def test_estimate_dir_size(small_sky_dir):
     estimate = estimate_dir_size(small_sky_dir)
@@ -38,15 +34,12 @@ def test_estimate_dir_size_edge(tmp_path):
     assert isinstance(estimate, int)
 
 
-# ---------------------------------------------------------------------------
-# get_mem_size_per_row: end-to-end on catalog data
-# ---------------------------------------------------------------------------
-
-
 def test_get_mem_size_per_row_pandas(small_sky_dir):
     small_sky_catalog = read_hats(small_sky_dir)
 
-    single_pixel_df = small_sky_catalog.read_pixel_to_pandas(small_sky_catalog.get_healpix_pixels()[0])
+    single_pixel_df = small_sky_catalog.read_pixel_to_pandas(
+        small_sky_catalog.get_healpix_pixels()[0]
+    )
     mem_sizes = get_mem_size_per_row(single_pixel_df)
     assert len(mem_sizes) == len(single_pixel_df)
 
@@ -74,7 +67,9 @@ def test_get_mem_size_per_row_pyarrow(small_sky_dir):
 def test_get_mem_size_per_row_pandas_nested(small_sky_nested_dir):
     small_sky_catalog = read_hats(small_sky_nested_dir)
 
-    single_pixel_df = small_sky_catalog.read_pixel_to_pandas(small_sky_catalog.get_healpix_pixels()[0])
+    single_pixel_df = small_sky_catalog.read_pixel_to_pandas(
+        small_sky_catalog.get_healpix_pixels()[0]
+    )
     mem_sizes = get_mem_size_per_row(single_pixel_df)
     assert len(mem_sizes) == len(single_pixel_df)
 
@@ -149,7 +144,9 @@ def test_get_mem_size_per_row_mixed_frame():
     assert len(mem_sizes_table_small) == 10
     assert all(isinstance(size, float) and size > 0 for size in mem_sizes_table_small)
     # Each entry in mem_sizes_table should be > corresponding entry in mem_sizes_table_small
-    assert all(m > s for m, s in zip(mem_sizes_table, mem_sizes_table_small, strict=True))
+    assert all(
+        m > s for m, s in zip(mem_sizes_table, mem_sizes_table_small, strict=True)
+    )
 
 
 def test_get_mem_size_per_row_nested_frame():
@@ -197,15 +194,16 @@ def test_get_mem_size_per_row_nested_frame():
     assert mem_sizes[2] > mem_sizes[0]
 
 
-# ---------------------------------------------------------------------------
-# get_mem_size_per_row: fixed-width and string/binary columns
-# ---------------------------------------------------------------------------
+def test_get_mem_size_per_row_fixed_and_string_columns():
+    """Fixed-width and string/binary columns are sized by value width and offsets:
 
-
-def test_get_mem_size_per_row_pyarrow_strings_and_fixed_widths():
-    """Fixed-width values cost their byte width (bit-packed bools count 1/8 byte);
-    string values cost their UTF-8 data bytes plus one offset entry, plus a
-    one-bit validity share since the null makes the column carry a bitmap."""
+    - fixed-width values cost their byte width (bit-packed bools count 1/8 byte);
+    - fixed-size binary reads its width from ``byte_width``;
+    - string/binary values cost their UTF-8 data bytes plus one offset entry
+      (4 bytes, or 8 for the ``large_`` variants);
+    - a null makes the column carry a validity bitmap, a 1/8-byte-per-row share.
+    """
+    # ints, bit-packed bools, and a string column whose null makes it carry a bitmap.
     table = pa.table(
         {
             "id": pa.array([1, 2, 3], type=pa.int64()),
@@ -213,193 +211,136 @@ def test_get_mem_size_per_row_pyarrow_strings_and_fixed_widths():
             "name": pa.array(["1001", None, "ééé"], type=pa.string()),
         }
     )
-
-    mem_sizes = get_mem_size_per_row(table)
-
     # id: 8 each; flag: 1/8 each; name: data bytes + 4-byte offset entry + 1/8
     # bitmap, where "ééé" is 6 UTF-8 bytes and the null row holds no data.
-    assert mem_sizes == [
+    assert get_mem_size_per_row(table) == [
         8 + 0.125 + (4 + 4 + 0.125),
         8 + 0.125 + (0 + 4 + 0.125),
         8 + 0.125 + (6 + 4 + 0.125),
     ]
 
+    # Fixed-size binary: every value costs its declared byte width (here 4); no
+    # nulls, so no bitmap share.
+    fixed_binary = get_mem_size_per_row(
+        pa.table({"fb": pa.array([b"abcd", b"efgh", b"ijkl"], pa.binary(4))})
+    )
+    assert fixed_binary == [4.0, 4.0, 4.0]
+    assert all(isinstance(size, float) for size in fixed_binary)
 
-def test_get_mem_size_per_row_pyarrow_fixed_size_binary():
-    """Fixed-size binary is a fixed-width type: every value costs its declared
-    byte width (here 4), read from ``byte_width`` rather than a bit width. No
-    nulls, so there is no validity bitmap share."""
-    table = pa.table({"fb": pa.array([b"abcd", b"efgh", b"ijkl"], type=pa.binary(4))})
-
-    mem_sizes = get_mem_size_per_row(table)
-
-    assert mem_sizes == [4.0, 4.0, 4.0]
-    assert all(isinstance(size, float) for size in mem_sizes)
-
-
-def test_get_mem_size_per_row_pyarrow_large_string():
-    """Large string/binary types index their values with 8-byte offset entries
-    (vs. 4 for their regular counterparts), so each row costs its UTF-8 data
-    bytes plus 8. No nulls, so no bitmap share."""
-    table = pa.table({"name": pa.array(["ab", "cde"], type=pa.large_string())})
-
-    mem_sizes = get_mem_size_per_row(table)
-
-    # "ab" = 2 data bytes + 8-byte offset; "cde" = 3 + 8.
-    assert mem_sizes == [10.0, 11.0]
-    assert all(isinstance(size, float) for size in mem_sizes)
+    # Large string: 8-byte offset entries instead of 4; no nulls, so no bitmap.
+    # "ab" = 2 data bytes + 8; "cde" = 3 + 8.
+    large_string = get_mem_size_per_row(
+        pa.table({"name": pa.array(["ab", "cde"], pa.large_string())})
+    )
+    assert large_string == [10.0, 11.0]
+    assert all(isinstance(size, float) for size in large_string)
 
 
-# ---------------------------------------------------------------------------
-# get_mem_size_per_row: list columns
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("list_type,offset_width", [(pa.list_, 4), (pa.large_list, 8)])
-def test_get_mem_size_per_row_pyarrow_list_columns(list_type, offset_width):
+def test_get_mem_size_per_row_list_columns():
     """List columns are sized from the arrow offsets: each row costs its slice of
-    the shared values buffer (element count x element width) plus one offset entry.
-    Null rows hold no data but still occupy an offset entry, and the null makes
-    the column carry a validity bitmap (one bit = 1/8 byte per row)."""
-    lightcurves = [[10.1, 10.3, 9.8], [], None, [4.2] * 100]
-    table = pa.table({"lightcurve": pa.array(lightcurves, type=list_type(pa.float64()))})
-
-    mem_sizes = get_mem_size_per_row(table)
-
+    the shared values buffer (element count x element width) plus one offset entry
+    (4 bytes, 8 for large lists), and a null makes the column carry a validity
+    bitmap (one bit = 1/8 byte per row)."""
     bitmap = 0.125
-    expected = [
-        3 * 8 + offset_width + bitmap,
-        offset_width + bitmap,
-        offset_width + bitmap,
-        100 * 8 + offset_width + bitmap,
+    lightcurves = [[10.1, 10.3, 9.8], [], None, [4.2] * 100]
+    for list_type, offset_width in [(pa.list_, 4), (pa.large_list, 8)]:
+        table = pa.table(
+            {"lightcurve": pa.array(lightcurves, type=list_type(pa.float64()))}
+        )
+        # Null rows hold no data but still occupy an offset entry.
+        assert get_mem_size_per_row(table) == [
+            3 * 8 + offset_width + bitmap,
+            offset_width + bitmap,
+            offset_width + bitmap,
+            100 * 8 + offset_width + bitmap,
+        ]
+
+    # Lists of variable-width elements (list<string>) attribute the elements' total
+    # buffer size uniformly per element, so longer rows cost proportionally more and
+    # the group total tracks the loaded buffers.
+    names = pa.array([["a", "bb"], ["ccc"], []], type=pa.list_(pa.string()))
+    mem_sizes = get_mem_size_per_row(pa.table({"names": names}))
+    assert all(isinstance(size, float) for size in mem_sizes)
+    # The empty row costs only its offset entry; longer rows cost more.
+    assert mem_sizes[0] > mem_sizes[1] > mem_sizes[2] == 4
+    # The model counts n offset entries per offsets buffer where the real buffer
+    # holds n + 1, so it undercounts one entry each for the outer and the
+    # flattened-string buffer.
+    assert sum(mem_sizes) == pytest.approx(names.nbytes, abs=8)
+
+
+def test_get_mem_size_per_row_struct_columns():
+    """Struct rows (e.g. nested columns) cost the sum of their fields, whether the
+    struct comes from a pyarrow table or from an object column of dict cells (which
+    infers the same arrow struct)."""
+    struct_rows = [
+        {"time": [1.0, 2.0, 3.0], "band": "g"},
+        {"time": [4.0], "band": "rr"},
     ]
+    struct_type = pa.struct([("time", pa.list_(pa.float64())), ("band", pa.string())])
+    # time: 8 x elements + 4-byte offset entry; band: UTF-8 bytes + 4-byte offset
+    # entry. No nulls, so no bitmap share.
+    expected = [(3 * 8 + 4) + (1 + 4), (1 * 8 + 4) + (2 + 4)]
+
+    table = pa.table({"lc": pa.array(struct_rows, type=struct_type)})
+    assert get_mem_size_per_row(table) == expected
+
+    # An object column of dict cells infers the same struct model; field order may
+    # differ after inference, but the per-row totals do not.
+    frame = pd.DataFrame({"lc": pd.Series(struct_rows, dtype=object)})
+    mem_sizes = get_mem_size_per_row(frame)
     assert mem_sizes == expected
     assert all(isinstance(size, float) for size in mem_sizes)
 
 
-def test_get_mem_size_per_row_pyarrow_list_of_strings():
-    """Lists of variable-width elements attribute the elements' total buffer size
-    uniformly per element, so longer rows cost proportionally more and the group
-    total tracks the loaded buffers."""
-    names = pa.array([["a", "bb"], ["ccc"], []], type=pa.list_(pa.string()))
-    table = pa.table({"names": names})
-
-    mem_sizes = get_mem_size_per_row(table)
-
-    assert all(isinstance(size, float) for size in mem_sizes)
-    # The empty row costs only its offset entry; longer rows cost more.
-    assert mem_sizes[0] > mem_sizes[1] > mem_sizes[2] == 4
-    # The total approximates the column's actual loaded buffers: the model counts
-    # n offset entries per offsets buffer where the real buffer holds n + 1, so
-    # it undercounts one entry each for the outer and the flattened-string buffer.
-    assert sum(mem_sizes) == pytest.approx(names.nbytes, abs=8)
-
-
-# ---------------------------------------------------------------------------
-# get_mem_size_per_row: struct columns
-# ---------------------------------------------------------------------------
-
-
-def test_get_mem_size_per_row_pyarrow_struct():
-    """Struct rows (e.g. nested columns) cost the sum of their fields."""
-    struct_rows = [
-        {"time": [1.0, 2.0, 3.0], "band": "g"},
-        {"time": [4.0], "band": "rr"},
-    ]
-    struct_type = pa.struct([("time", pa.list_(pa.float64())), ("band", pa.string())])
-    table = pa.table({"lc": pa.array(struct_rows, type=struct_type)})
-
-    mem_sizes = get_mem_size_per_row(table)
-
-    # time: 8 x elements + 4-byte offset entry; band: UTF-8 bytes + 4-byte offset entry.
-    assert mem_sizes == [(3 * 8 + 4) + (1 + 4), (1 * 8 + 4) + (2 + 4)]
-
-
-def test_get_mem_size_per_row_pandas_struct_matches_pyarrow():
-    """An object column of dict cells converts to an arrow struct, so it is measured
-    with the same struct model (sum of fields) as the equivalent arrow table. Field
-    order may differ after inference, but the per-row totals do not."""
-    struct_rows = [
-        {"time": [1.0, 2.0, 3.0], "band": "g"},
-        {"time": [4.0], "band": "rr"},
-    ]
-    struct_type = pa.struct([("time", pa.list_(pa.float64())), ("band", pa.string())])
-    frame = pd.DataFrame({"lc": pd.Series(struct_rows, dtype=object)})
-    table = pa.table({"lc": pa.array(struct_rows, type=struct_type)})
-
-    mem_sizes = get_mem_size_per_row(frame)
-
-    # Same field arithmetic as the pyarrow struct test: no nulls, so no bitmap share.
-    assert mem_sizes == [(3 * 8 + 4) + (1 + 4), (1 * 8 + 4) + (2 + 4)]
-    assert mem_sizes == get_mem_size_per_row(table)
-    assert all(isinstance(size, float) for size in mem_sizes)
-
-
-# ---------------------------------------------------------------------------
-# get_mem_size_per_row: pandas columns arrow can't represent (per-item fallback)
-# ---------------------------------------------------------------------------
-
-
-def test_get_mem_size_per_row_pandas_numpy_scalar_cells():
-    """An object column of numpy scalar cells (e.g. structured np.void records)
-    cannot be converted to arrow, so it falls back to per-item measurement. The
-    cell is sized by its buffer (itemsize), not the Python wrapper's overhead."""
+def test_get_mem_size_per_row_pandas_non_arrow_columns():
+    """Object columns arrow can't represent fall back to per-item measurement,
+    sized by the underlying buffer rather than the Python wrapper's overhead:
+    ndarray cells by ``nbytes``, numpy scalars by ``itemsize``, and any other
+    Python object by ``sys.getsizeof``."""
+    # Numpy scalar cells (structured np.void records): sized by itemsize. Two
+    # float64 fields => 16 bytes per record, regardless of Python overhead.
     record_type = np.dtype([("x", np.float64), ("y", np.float64)])
     records = np.array([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dtype=record_type)
-    # Each cell is a np.void scalar; a DataFrame keeps them as an object column.
     frame = pd.DataFrame({"record": pd.Series(list(records), dtype=object)})
-
     mem_sizes = get_mem_size_per_row(frame)
-
-    # Two float64 fields => 16 bytes per record, regardless of Python overhead.
     assert mem_sizes == [16.0, 16.0, 16.0]
     assert all(isinstance(size, float) for size in mem_sizes)
 
-
-def test_get_mem_size_per_row_pandas_ndarray_cells():
-    """An object column of ragged ndarray cells cannot be converted to a single
-    arrow type, so it falls back to per-item measurement. An ndarray cell is
-    sized by its buffer (``nbytes``), excluding the Python wrapper's overhead."""
-    # A 1-D and a 2-D array in one object column: arrow cannot unify the shapes.
-    cells = [np.array([1, 2], dtype=np.int64), np.array([[1, 2], [3, 4]], dtype=np.int64)]
+    # Ragged ndarray cells (a 1-D and a 2-D array) can't be unified into one arrow
+    # type; each is sized by its buffer. 2 x int64 = 16 bytes; 4 x int64 = 32 bytes.
+    cells = [
+        np.array([1, 2], dtype=np.int64),
+        np.array([[1, 2], [3, 4]], dtype=np.int64),
+    ]
     frame = pd.DataFrame({"arr": pd.Series(cells, dtype=object)})
+    assert get_mem_size_per_row(frame) == [16.0, 32.0]
 
-    mem_sizes = get_mem_size_per_row(frame)
-
-    # 2 x int64 = 16 bytes; 4 x int64 = 32 bytes.
-    assert mem_sizes == [16.0, 32.0]
-    assert all(isinstance(size, float) for size in mem_sizes)
-
-
-def test_get_mem_size_per_row_pandas_unconvertible_object_cells():
-    """An object column of arbitrary Python objects (neither ndarray nor numpy
-    scalar) that arrow cannot represent falls back to ``sys.getsizeof`` per cell."""
-
+    # Arbitrary Python objects (neither ndarray nor numpy scalar): sys.getsizeof.
     class Opaque:
         pass
 
-    cells = [Opaque(), Opaque()]
-    frame = pd.DataFrame({"obj": pd.Series(cells, dtype=object)})
-
-    mem_sizes = get_mem_size_per_row(frame)
-
-    assert mem_sizes == [float(sys.getsizeof(cell)) for cell in cells]
-    assert all(isinstance(size, float) for size in mem_sizes)
+    opaque = [Opaque(), Opaque()]
+    frame = pd.DataFrame({"obj": pd.Series(opaque, dtype=object)})
+    assert get_mem_size_per_row(frame) == [
+        float(sys.getsizeof(cell)) for cell in opaque
+    ]
 
 
-# ---------------------------------------------------------------------------
-# get_mem_size_per_row: pandas/pyarrow equivalence and column selection
-# ---------------------------------------------------------------------------
-
-
-def test_get_mem_size_per_row_pandas_matches_pyarrow():
-    """A pandas chunk (numerics, strings, ndarray list cells) measures the same as
-    the equivalent arrow table, since pandas columns are converted before measuring."""
+def test_get_mem_size_per_row_pandas_pyarrow_equivalence_and_cols():
+    """A pandas chunk measures the same as its equivalent arrow table (columns are
+    converted before measuring), and passing ``cols`` restricts the measurement to
+    those columns for both pandas and pyarrow inputs."""
+    # Equivalence: numerics, strings, and ndarray list cells measure identically.
     frame = pd.DataFrame(
         {
             "ra": [290.0, 300.0, 310.0],
             "id_str": ["1001", "1002", "1003"],
-            "mags": [np.array([1.0, 2.0]), np.array([3.0]), np.array([], dtype=np.float64)],
+            "mags": [
+                np.array([1.0, 2.0]),
+                np.array([3.0]),
+                np.array([], dtype=np.float64),
+            ],
         }
     )
     table = pa.table(
@@ -409,13 +350,10 @@ def test_get_mem_size_per_row_pandas_matches_pyarrow():
             "mags": pa.array([[1.0, 2.0], [3.0], []], type=pa.list_(pa.float64())),
         }
     )
-
     assert get_mem_size_per_row(frame) == get_mem_size_per_row(table)
 
-
-def test_get_mem_size_per_row_pandas_cols_selection():
-    """Passing ``cols`` restricts the pandas measurement to those columns, giving
-    the same result as measuring the pre-selected frame and less than the full frame."""
+    # Column selection restricts the measurement to the named columns, matching a
+    # pre-selection; dropping the string column lowers every row's size.
     frame = pd.DataFrame(
         {
             "id": pa.array([1, 2, 3], type=pa.int64()).to_pandas(),
@@ -423,17 +361,12 @@ def test_get_mem_size_per_row_pandas_cols_selection():
             "name": ["aaaa", "bb", "c"],
         }
     )
-
     selected = get_mem_size_per_row(frame, cols=["id", "ra"])
-
     assert selected == get_mem_size_per_row(frame[["id", "ra"]])
-    # Dropping the string column lowers every row's size.
-    assert all(s < full for s, full in zip(selected, get_mem_size_per_row(frame), strict=True))
+    assert all(
+        s < full for s, full in zip(selected, get_mem_size_per_row(frame), strict=True)
+    )
 
-
-def test_get_mem_size_per_row_pyarrow_cols_selection():
-    """Passing ``cols`` restricts the pyarrow measurement to those columns, giving
-    the same result as selecting them on the table and less than the full table."""
     table = pa.table(
         {
             "id": pa.array([1, 2, 3], type=pa.int64()),
@@ -441,17 +374,11 @@ def test_get_mem_size_per_row_pyarrow_cols_selection():
             "name": pa.array(["aaaa", "bb", "c"], type=pa.string()),
         }
     )
-
     selected = get_mem_size_per_row(table, cols=["id", "ra"])
-
     assert selected == get_mem_size_per_row(table.select(["id", "ra"]))
-    # Dropping the string column lowers every row's size.
-    assert all(s < full for s, full in zip(selected, get_mem_size_per_row(table), strict=True))
-
-
-# ---------------------------------------------------------------------------
-# get_mem_size_per_row: edge cases
-# ---------------------------------------------------------------------------
+    assert all(
+        s < full for s, full in zip(selected, get_mem_size_per_row(table), strict=True)
+    )
 
 
 def test_get_mem_size_per_row_pyarrow_empty_fixed_width():

--- a/tests/hats/io/test_size_estimates.py
+++ b/tests/hats/io/test_size_estimates.py
@@ -1,3 +1,5 @@
+import sys
+
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
@@ -8,6 +10,10 @@ from hats import read_hats
 from hats.io.file_io import read_parquet_file
 from hats.io.paths import pixel_catalog_file
 from hats.io.size_estimates import estimate_dir_size, get_mem_size_per_row
+
+# ---------------------------------------------------------------------------
+# estimate_dir_size
+# ---------------------------------------------------------------------------
 
 
 def test_estimate_dir_size(small_sky_dir):
@@ -30,6 +36,11 @@ def test_estimate_dir_size_edge(tmp_path):
     estimate = estimate_dir_size("")
     assert estimate == 0
     assert isinstance(estimate, int)
+
+
+# ---------------------------------------------------------------------------
+# get_mem_size_per_row: end-to-end on catalog data
+# ---------------------------------------------------------------------------
 
 
 def test_get_mem_size_per_row_pandas(small_sky_dir):
@@ -83,14 +94,14 @@ def test_get_mem_size_per_row_errors(small_sky_dir):
         get_mem_size_per_row(single_pixel_table)
 
 
-def test_get_mem_size_of_chunk():
-    """Test the _get_mem_size_of_chunk function for reasonable outputs."""
-    # Test with an empty DataFrame
+def test_get_mem_size_per_row_mixed_frame():
+    """A realistic multi-column frame: sizes are positive, dropping columns shrinks
+    every row, and a pandas frame measures the same as its equivalent pyarrow table."""
+    # An empty frame has no rows to measure.
     empty_df = pd.DataFrame(columns=["id", "ra", "dec", "value"])
     mem_sizes_empty = get_mem_size_per_row(empty_df)
     assert len(mem_sizes_empty) == 0
 
-    # Test with a small DataFrame
     df = pd.DataFrame(
         {
             "id": [0, 0, 0, 1, 1, 1, 2, 2, 2, 2],
@@ -115,7 +126,7 @@ def test_get_mem_size_of_chunk():
     mem_sizes = get_mem_size_per_row(df)
     # Since we have 10 rows, mem_sizes should have length 10
     assert len(mem_sizes) == 10
-    # Each entry should be a positive integer (size in bytes)
+    # Each entry should be a positive float (size in bytes)
     assert all(isinstance(size, float) and size > 0 for size in mem_sizes)
 
     # Compare to a smaller DataFrame with fewer columns
@@ -141,8 +152,8 @@ def test_get_mem_size_of_chunk():
     assert all(m > s for m, s in zip(mem_sizes_table, mem_sizes_table_small, strict=True))
 
 
-def test_get_mem_size_of_chunk_nested():
-    """Test the _get_mem_size_of_chunk function with nested data."""
+def test_get_mem_size_per_row_nested_frame():
+    """A nested (light-curve) frame: rows with more sub-rows cost more."""
     # Create a small DataFrame and nest it
     df = pd.DataFrame(
         {
@@ -178,12 +189,70 @@ def test_get_mem_size_of_chunk_nested():
 
     # Since we have only 3 rows once we nest, mem_sizes should have length 3
     assert len(mem_sizes) == 3
-    # Each entry should be a positive integer (size in bytes)
+    # Each entry should be a positive float (size in bytes)
     assert all(isinstance(size, float) and size > 0 for size in mem_sizes)
     # The first two entries should be the same, since they have 3 sub-rows each
     assert mem_sizes[0] == mem_sizes[1]
     # The last entry should be the larger than the other two, since it has 4 sub-rows
     assert mem_sizes[2] > mem_sizes[0]
+
+
+# ---------------------------------------------------------------------------
+# get_mem_size_per_row: fixed-width and string/binary columns
+# ---------------------------------------------------------------------------
+
+
+def test_get_mem_size_per_row_pyarrow_strings_and_fixed_widths():
+    """Fixed-width values cost their byte width (bit-packed bools count 1/8 byte);
+    string values cost their UTF-8 data bytes plus one offset entry, plus a
+    one-bit validity share since the null makes the column carry a bitmap."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int64()),
+            "flag": pa.array([True, False, True], type=pa.bool_()),
+            "name": pa.array(["1001", None, "ééé"], type=pa.string()),
+        }
+    )
+
+    mem_sizes = get_mem_size_per_row(table)
+
+    # id: 8 each; flag: 1/8 each; name: data bytes + 4-byte offset entry + 1/8
+    # bitmap, where "ééé" is 6 UTF-8 bytes and the null row holds no data.
+    assert mem_sizes == [
+        8 + 0.125 + (4 + 4 + 0.125),
+        8 + 0.125 + (0 + 4 + 0.125),
+        8 + 0.125 + (6 + 4 + 0.125),
+    ]
+
+
+def test_get_mem_size_per_row_pyarrow_fixed_size_binary():
+    """Fixed-size binary is a fixed-width type: every value costs its declared
+    byte width (here 4), read from ``byte_width`` rather than a bit width. No
+    nulls, so there is no validity bitmap share."""
+    table = pa.table({"fb": pa.array([b"abcd", b"efgh", b"ijkl"], type=pa.binary(4))})
+
+    mem_sizes = get_mem_size_per_row(table)
+
+    assert mem_sizes == [4.0, 4.0, 4.0]
+    assert all(isinstance(size, float) for size in mem_sizes)
+
+
+def test_get_mem_size_per_row_pyarrow_large_string():
+    """Large string/binary types index their values with 8-byte offset entries
+    (vs. 4 for their regular counterparts), so each row costs its UTF-8 data
+    bytes plus 8. No nulls, so no bitmap share."""
+    table = pa.table({"name": pa.array(["ab", "cde"], type=pa.large_string())})
+
+    mem_sizes = get_mem_size_per_row(table)
+
+    # "ab" = 2 data bytes + 8-byte offset; "cde" = 3 + 8.
+    assert mem_sizes == [10.0, 11.0]
+    assert all(isinstance(size, float) for size in mem_sizes)
+
+
+# ---------------------------------------------------------------------------
+# get_mem_size_per_row: list columns
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("list_type,offset_width", [(pa.list_, 4), (pa.large_list, 8)])
@@ -226,27 +295,9 @@ def test_get_mem_size_per_row_pyarrow_list_of_strings():
     assert sum(mem_sizes) == pytest.approx(names.nbytes, abs=8)
 
 
-def test_get_mem_size_per_row_pyarrow_strings_and_fixed_widths():
-    """Fixed-width values cost their byte width (bit-packed bools count 1/8 byte);
-    string values cost their UTF-8 data bytes plus one offset entry, plus a
-    one-bit validity share since the null makes the column carry a bitmap."""
-    table = pa.table(
-        {
-            "id": pa.array([1, 2, 3], type=pa.int64()),
-            "flag": pa.array([True, False, True], type=pa.bool_()),
-            "name": pa.array(["1001", None, "ééé"], type=pa.string()),
-        }
-    )
-
-    mem_sizes = get_mem_size_per_row(table)
-
-    # id: 8 each; flag: 1/8 each; name: data bytes + 4-byte offset entry + 1/8
-    # bitmap, where "ééé" is 6 UTF-8 bytes and the null row holds no data.
-    assert mem_sizes == [
-        8 + 0.125 + (4 + 4 + 0.125),
-        8 + 0.125 + (0 + 4 + 0.125),
-        8 + 0.125 + (6 + 4 + 0.125),
-    ]
+# ---------------------------------------------------------------------------
+# get_mem_size_per_row: struct columns
+# ---------------------------------------------------------------------------
 
 
 def test_get_mem_size_per_row_pyarrow_struct():
@@ -284,6 +335,63 @@ def test_get_mem_size_per_row_pandas_struct_matches_pyarrow():
     assert all(isinstance(size, float) for size in mem_sizes)
 
 
+# ---------------------------------------------------------------------------
+# get_mem_size_per_row: pandas columns arrow can't represent (per-item fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_get_mem_size_per_row_pandas_numpy_scalar_cells():
+    """An object column of numpy scalar cells (e.g. structured np.void records)
+    cannot be converted to arrow, so it falls back to per-item measurement. The
+    cell is sized by its buffer (itemsize), not the Python wrapper's overhead."""
+    record_type = np.dtype([("x", np.float64), ("y", np.float64)])
+    records = np.array([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dtype=record_type)
+    # Each cell is a np.void scalar; a DataFrame keeps them as an object column.
+    frame = pd.DataFrame({"record": pd.Series(list(records), dtype=object)})
+
+    mem_sizes = get_mem_size_per_row(frame)
+
+    # Two float64 fields => 16 bytes per record, regardless of Python overhead.
+    assert mem_sizes == [16.0, 16.0, 16.0]
+    assert all(isinstance(size, float) for size in mem_sizes)
+
+
+def test_get_mem_size_per_row_pandas_ndarray_cells():
+    """An object column of ragged ndarray cells cannot be converted to a single
+    arrow type, so it falls back to per-item measurement. An ndarray cell is
+    sized by its buffer (``nbytes``), excluding the Python wrapper's overhead."""
+    # A 1-D and a 2-D array in one object column: arrow cannot unify the shapes.
+    cells = [np.array([1, 2], dtype=np.int64), np.array([[1, 2], [3, 4]], dtype=np.int64)]
+    frame = pd.DataFrame({"arr": pd.Series(cells, dtype=object)})
+
+    mem_sizes = get_mem_size_per_row(frame)
+
+    # 2 x int64 = 16 bytes; 4 x int64 = 32 bytes.
+    assert mem_sizes == [16.0, 32.0]
+    assert all(isinstance(size, float) for size in mem_sizes)
+
+
+def test_get_mem_size_per_row_pandas_unconvertible_object_cells():
+    """An object column of arbitrary Python objects (neither ndarray nor numpy
+    scalar) that arrow cannot represent falls back to ``sys.getsizeof`` per cell."""
+
+    class Opaque:
+        pass
+
+    cells = [Opaque(), Opaque()]
+    frame = pd.DataFrame({"obj": pd.Series(cells, dtype=object)})
+
+    mem_sizes = get_mem_size_per_row(frame)
+
+    assert mem_sizes == [float(sys.getsizeof(cell)) for cell in cells]
+    assert all(isinstance(size, float) for size in mem_sizes)
+
+
+# ---------------------------------------------------------------------------
+# get_mem_size_per_row: pandas/pyarrow equivalence and column selection
+# ---------------------------------------------------------------------------
+
+
 def test_get_mem_size_per_row_pandas_matches_pyarrow():
     """A pandas chunk (numerics, strings, ndarray list cells) measures the same as
     the equivalent arrow table, since pandas columns are converted before measuring."""
@@ -305,17 +413,50 @@ def test_get_mem_size_per_row_pandas_matches_pyarrow():
     assert get_mem_size_per_row(frame) == get_mem_size_per_row(table)
 
 
-def test_get_mem_size_per_row_pandas_numpy_scalar_cells():
-    """An object column of numpy scalar cells (e.g. structured np.void records)
-    cannot be converted to arrow, so it falls back to per-item measurement. The
-    cell is sized by its buffer (itemsize), not the Python wrapper's overhead."""
-    record_type = np.dtype([("x", np.float64), ("y", np.float64)])
-    records = np.array([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], dtype=record_type)
-    # Each cell is a np.void scalar; a DataFrame keeps them as an object column.
-    frame = pd.DataFrame({"record": pd.Series(list(records), dtype=object)})
+def test_get_mem_size_per_row_pandas_cols_selection():
+    """Passing ``cols`` restricts the pandas measurement to those columns, giving
+    the same result as measuring the pre-selected frame and less than the full frame."""
+    frame = pd.DataFrame(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int64()).to_pandas(),
+            "ra": [10.0, 15.0, 12.1],
+            "name": ["aaaa", "bb", "c"],
+        }
+    )
 
-    mem_sizes = get_mem_size_per_row(frame)
+    selected = get_mem_size_per_row(frame, cols=["id", "ra"])
 
-    # Two float64 fields => 16 bytes per record, regardless of Python overhead.
-    assert mem_sizes == [16.0, 16.0, 16.0]
-    assert all(isinstance(size, float) for size in mem_sizes)
+    assert selected == get_mem_size_per_row(frame[["id", "ra"]])
+    # Dropping the string column lowers every row's size.
+    assert all(s < full for s, full in zip(selected, get_mem_size_per_row(frame), strict=True))
+
+
+def test_get_mem_size_per_row_pyarrow_cols_selection():
+    """Passing ``cols`` restricts the pyarrow measurement to those columns, giving
+    the same result as selecting them on the table and less than the full table."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int64()),
+            "ra": pa.array([10.0, 15.0, 12.1], type=pa.float64()),
+            "name": pa.array(["aaaa", "bb", "c"], type=pa.string()),
+        }
+    )
+
+    selected = get_mem_size_per_row(table, cols=["id", "ra"])
+
+    assert selected == get_mem_size_per_row(table.select(["id", "ra"]))
+    # Dropping the string column lowers every row's size.
+    assert all(s < full for s, full in zip(selected, get_mem_size_per_row(table), strict=True))
+
+
+# ---------------------------------------------------------------------------
+# get_mem_size_per_row: edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_get_mem_size_per_row_pyarrow_empty_fixed_width():
+    """An empty fixed-width column has no rows to share a validity bitmap, so the
+    bitmap share is zero and the per-row list is empty."""
+    table = pa.table({"id": pa.array([], type=pa.int64())})
+
+    assert get_mem_size_per_row(table) == []

--- a/tests/hats/io/test_size_estimates.py
+++ b/tests/hats/io/test_size_estimates.py
@@ -264,6 +264,26 @@ def test_get_mem_size_per_row_pyarrow_struct():
     assert mem_sizes == [(3 * 8 + 4) + (1 + 4), (1 * 8 + 4) + (2 + 4)]
 
 
+def test_get_mem_size_per_row_pandas_struct_matches_pyarrow():
+    """An object column of dict cells converts to an arrow struct, so it is measured
+    with the same struct model (sum of fields) as the equivalent arrow table. Field
+    order may differ after inference, but the per-row totals do not."""
+    struct_rows = [
+        {"time": [1.0, 2.0, 3.0], "band": "g"},
+        {"time": [4.0], "band": "rr"},
+    ]
+    struct_type = pa.struct([("time", pa.list_(pa.float64())), ("band", pa.string())])
+    frame = pd.DataFrame({"lc": pd.Series(struct_rows, dtype=object)})
+    table = pa.table({"lc": pa.array(struct_rows, type=struct_type)})
+
+    mem_sizes = get_mem_size_per_row(frame)
+
+    # Same field arithmetic as the pyarrow struct test: no nulls, so no bitmap share.
+    assert mem_sizes == [(3 * 8 + 4) + (1 + 4), (1 * 8 + 4) + (2 + 4)]
+    assert mem_sizes == get_mem_size_per_row(table)
+    assert all(isinstance(size, float) for size in mem_sizes)
+
+
 def test_get_mem_size_per_row_pandas_matches_pyarrow():
     """A pandas chunk (numerics, strings, ndarray list cells) measures the same as
     the equivalent arrow table, since pandas columns are converted before measuring."""

--- a/tests/hats/io/test_size_estimates.py
+++ b/tests/hats/io/test_size_estimates.py
@@ -184,3 +184,89 @@ def test_get_mem_size_of_chunk_nested():
     assert mem_sizes[0] == mem_sizes[1]
     # The last entry should be the larger than the other two, since it has 4 sub-rows
     assert mem_sizes[2] > mem_sizes[0]
+
+
+@pytest.mark.parametrize("list_type,offset_width", [(pa.list_, 4), (pa.large_list, 8)])
+def test_get_mem_size_per_row_pyarrow_list_columns(list_type, offset_width):
+    """List columns are sized from the arrow offsets: each row costs its slice of
+    the shared values buffer (element count x element width) plus one offset entry.
+    Null rows hold no data but still occupy an offset entry."""
+    lightcurves = [[10.1, 10.3, 9.8], [], None, [4.2] * 100]
+    table = pa.table({"lightcurve": pa.array(lightcurves, type=list_type(pa.float64()))})
+
+    mem_sizes = get_mem_size_per_row(table)
+
+    expected = [3 * 8 + offset_width, offset_width, offset_width, 100 * 8 + offset_width]
+    assert mem_sizes == expected
+    assert all(isinstance(size, int) for size in mem_sizes)
+
+
+def test_get_mem_size_per_row_pyarrow_list_of_strings():
+    """Lists of variable-width elements attribute the elements' total buffer size
+    uniformly per element, so longer rows cost proportionally more and the group
+    total tracks the loaded buffers."""
+    names = pa.array([["a", "bb"], ["ccc"], []], type=pa.list_(pa.string()))
+    table = pa.table({"names": names})
+
+    mem_sizes = get_mem_size_per_row(table)
+
+    assert all(isinstance(size, int) for size in mem_sizes)
+    # The empty row costs only its offset entry; longer rows cost more.
+    assert mem_sizes[0] > mem_sizes[1] > mem_sizes[2] == 4
+    # The total approximates the column's actual loaded buffers (int truncation
+    # per row can lose up to a byte each).
+    assert sum(mem_sizes) == pytest.approx(names.nbytes, abs=len(mem_sizes))
+
+
+def test_get_mem_size_per_row_pyarrow_strings_and_fixed_widths():
+    """Fixed-width values cost their byte width (bools count as one byte); string
+    values cost their UTF-8 data bytes plus one offset entry."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int64()),
+            "flag": pa.array([True, False, True], type=pa.bool_()),
+            "name": pa.array(["1001", None, "ééé"], type=pa.string()),
+        }
+    )
+
+    mem_sizes = get_mem_size_per_row(table)
+
+    # id: 8 each; flag: 1 each; name: data bytes + 4-byte offset entry,
+    # where "ééé" is 6 UTF-8 bytes and the null row holds no data.
+    assert mem_sizes == [8 + 1 + (4 + 4), 8 + 1 + (0 + 4), 8 + 1 + (6 + 4)]
+
+
+def test_get_mem_size_per_row_pyarrow_struct():
+    """Struct rows (e.g. nested columns) cost the sum of their fields."""
+    struct_rows = [
+        {"time": [1.0, 2.0, 3.0], "band": "g"},
+        {"time": [4.0], "band": "rr"},
+    ]
+    struct_type = pa.struct([("time", pa.list_(pa.float64())), ("band", pa.string())])
+    table = pa.table({"lc": pa.array(struct_rows, type=struct_type)})
+
+    mem_sizes = get_mem_size_per_row(table)
+
+    # time: 8 x elements + 4-byte offset entry; band: UTF-8 bytes + 4-byte offset entry.
+    assert mem_sizes == [(3 * 8 + 4) + (1 + 4), (1 * 8 + 4) + (2 + 4)]
+
+
+def test_get_mem_size_per_row_pandas_matches_pyarrow():
+    """A pandas chunk (numerics, strings, ndarray list cells) measures the same as
+    the equivalent arrow table, since pandas columns are converted before measuring."""
+    frame = pd.DataFrame(
+        {
+            "ra": [290.0, 300.0, 310.0],
+            "id_str": ["1001", "1002", "1003"],
+            "mags": [np.array([1.0, 2.0]), np.array([3.0]), np.array([], dtype=np.float64)],
+        }
+    )
+    table = pa.table(
+        {
+            "ra": pa.array(frame["ra"], type=pa.float64()),
+            "id_str": pa.array(frame["id_str"], type=pa.string()),
+            "mags": pa.array([[1.0, 2.0], [3.0], []], type=pa.list_(pa.float64())),
+        }
+    )
+
+    assert get_mem_size_per_row(frame) == get_mem_size_per_row(table)

--- a/tests/hats/io/test_size_estimates.py
+++ b/tests/hats/io/test_size_estimates.py
@@ -116,13 +116,13 @@ def test_get_mem_size_of_chunk():
     # Since we have 10 rows, mem_sizes should have length 10
     assert len(mem_sizes) == 10
     # Each entry should be a positive integer (size in bytes)
-    assert all(isinstance(size, int) and size > 0 for size in mem_sizes)
+    assert all(isinstance(size, float) and size > 0 for size in mem_sizes)
 
     # Compare to a smaller DataFrame with fewer columns
     df_small = df[["id", "ra", "dec"]]
     mem_sizes_small = get_mem_size_per_row(df_small)
     assert len(mem_sizes_small) == 10
-    assert all(isinstance(size, int) and size > 0 for size in mem_sizes_small)
+    assert all(isinstance(size, float) and size > 0 for size in mem_sizes_small)
     # Each entry in mem_sizes should be > corresponding entry in mem_sizes_small
     assert all(m > s for m, s in zip(mem_sizes, mem_sizes_small, strict=True))
 
@@ -130,13 +130,13 @@ def test_get_mem_size_of_chunk():
     table = pa.Table.from_pandas(df)
     mem_sizes_table = get_mem_size_per_row(table)
     assert len(mem_sizes_table) == 10
-    assert all(isinstance(size, int) and size > 0 for size in mem_sizes_table)
+    assert all(isinstance(size, float) and size > 0 for size in mem_sizes_table)
 
     # Test with a smaller pyarrow Table
     table_small = pa.Table.from_pandas(df_small)
     mem_sizes_table_small = get_mem_size_per_row(table_small)
     assert len(mem_sizes_table_small) == 10
-    assert all(isinstance(size, int) and size > 0 for size in mem_sizes_table_small)
+    assert all(isinstance(size, float) and size > 0 for size in mem_sizes_table_small)
     # Each entry in mem_sizes_table should be > corresponding entry in mem_sizes_table_small
     assert all(m > s for m, s in zip(mem_sizes_table, mem_sizes_table_small, strict=True))
 
@@ -179,7 +179,7 @@ def test_get_mem_size_of_chunk_nested():
     # Since we have only 3 rows once we nest, mem_sizes should have length 3
     assert len(mem_sizes) == 3
     # Each entry should be a positive integer (size in bytes)
-    assert all(isinstance(size, int) and size > 0 for size in mem_sizes)
+    assert all(isinstance(size, float) and size > 0 for size in mem_sizes)
     # The first two entries should be the same, since they have 3 sub-rows each
     assert mem_sizes[0] == mem_sizes[1]
     # The last entry should be the larger than the other two, since it has 4 sub-rows
@@ -190,15 +190,22 @@ def test_get_mem_size_of_chunk_nested():
 def test_get_mem_size_per_row_pyarrow_list_columns(list_type, offset_width):
     """List columns are sized from the arrow offsets: each row costs its slice of
     the shared values buffer (element count x element width) plus one offset entry.
-    Null rows hold no data but still occupy an offset entry."""
+    Null rows hold no data but still occupy an offset entry, and the null makes
+    the column carry a validity bitmap (one bit = 1/8 byte per row)."""
     lightcurves = [[10.1, 10.3, 9.8], [], None, [4.2] * 100]
     table = pa.table({"lightcurve": pa.array(lightcurves, type=list_type(pa.float64()))})
 
     mem_sizes = get_mem_size_per_row(table)
 
-    expected = [3 * 8 + offset_width, offset_width, offset_width, 100 * 8 + offset_width]
+    bitmap = 0.125
+    expected = [
+        3 * 8 + offset_width + bitmap,
+        offset_width + bitmap,
+        offset_width + bitmap,
+        100 * 8 + offset_width + bitmap,
+    ]
     assert mem_sizes == expected
-    assert all(isinstance(size, int) for size in mem_sizes)
+    assert all(isinstance(size, float) for size in mem_sizes)
 
 
 def test_get_mem_size_per_row_pyarrow_list_of_strings():
@@ -210,17 +217,19 @@ def test_get_mem_size_per_row_pyarrow_list_of_strings():
 
     mem_sizes = get_mem_size_per_row(table)
 
-    assert all(isinstance(size, int) for size in mem_sizes)
+    assert all(isinstance(size, float) for size in mem_sizes)
     # The empty row costs only its offset entry; longer rows cost more.
     assert mem_sizes[0] > mem_sizes[1] > mem_sizes[2] == 4
-    # The total approximates the column's actual loaded buffers (int truncation
-    # per row can lose up to a byte each).
-    assert sum(mem_sizes) == pytest.approx(names.nbytes, abs=len(mem_sizes))
+    # The total approximates the column's actual loaded buffers: the model counts
+    # n offset entries per offsets buffer where the real buffer holds n + 1, so
+    # it undercounts one entry each for the outer and the flattened-string buffer.
+    assert sum(mem_sizes) == pytest.approx(names.nbytes, abs=8)
 
 
 def test_get_mem_size_per_row_pyarrow_strings_and_fixed_widths():
-    """Fixed-width values cost their byte width (bools count as one byte); string
-    values cost their UTF-8 data bytes plus one offset entry."""
+    """Fixed-width values cost their byte width (bit-packed bools count 1/8 byte);
+    string values cost their UTF-8 data bytes plus one offset entry, plus a
+    one-bit validity share since the null makes the column carry a bitmap."""
     table = pa.table(
         {
             "id": pa.array([1, 2, 3], type=pa.int64()),
@@ -231,9 +240,9 @@ def test_get_mem_size_per_row_pyarrow_strings_and_fixed_widths():
 
     mem_sizes = get_mem_size_per_row(table)
 
-    # id: 8 each; flag: 1 each; name: data bytes + 4-byte offset entry,
-    # where "ééé" is 6 UTF-8 bytes and the null row holds no data.
-    assert mem_sizes == [8 + 1 + (4 + 4), 8 + 1 + (0 + 4), 8 + 1 + (6 + 4)]
+    # id: 8 each; flag: 1/8 each; name: data bytes + 4-byte offset entry + 1/8
+    # bitmap, where "ééé" is 6 UTF-8 bytes and the null row holds no data.
+    assert mem_sizes == [8 + 0.125 + (4 + 4 + 0.125), 8 + 0.125 + (0 + 4 + 0.125), 8 + 0.125 + (6 + 4 + 0.125)]
 
 
 def test_get_mem_size_per_row_pyarrow_struct():


### PR DESCRIPTION
## Change Description

Part of HI-671 (memory-size partitioning). Paired with the corresponding hats-import PR.

Reworks per-row memory-size estimation (`hats.io.size_estimates.get_mem_size_per_row`) from a slow (and inaccurate!), row-by-row `sys.getsizeof()` walk into a fast, column-wise estimate that models the actual loaded arrow-buffer footprint. 

This fn is the sizing engine behind hats-import's `byte_pixel_threshold` partitioning.

## Solution Description

`get_mem_size_per_row(data, cols=None)` now measures each column once, using the columnar arrow representation the data occupies when loaded (i.e. it is designed to reproduce `Table.nbytes` when summed over a partition), instead of iterating rows and summing Python object sizes:

- **Fixed-width types** (int/float/bool/decimal/temporal/fixed-size-binary): the value's true byte width, with bit-packed booleans correctly counted at 1/8 byte.
- **Strings/binary**: UTF-8 data bytes (via `pc.binary_length` over the whole column, no per-value Python conversion) plus one offset entry (4 bytes, or 8 for `large_*`).
- **Lists**: element count (`pc.list_value_length`) × element width — fixed-width elements get their real width, variable-width elements (e.g. `list<string>`) are attributed the column's average element size — plus one offset entry.
- **Structs / nested columns**: recursive sum of each field's contribution.
- **Validity bitmaps**: 1/8 byte per row, counted only when the array actually carries a materialized bitmap (checked via `buffers()[0]`, not null count, so all-valid bitmaps materialized by the parquet reader are still accounted for).
- **Anything else** (dictionary, union, ...): total `nbytes` spread uniformly.
- **pandas inputs** are opportunistically converted per-column with `pa.array(series, from_pandas=True)` and measured with the exact same model, so a pandas chunk and the equivalent arrow table produce identical estimates. Columns arrow cannot represent fall back to a best-effort per-item measurement, which uses `.nbytes`/`.itemsize` for numpy arrays and scalars (avoiding the Python-wrapper overhead that `sys.getsizeof` would report).

New `cols=` parameter restricts measurement to a subset of columns — this is what lets hats-import measure only the columns that genuinely need per-row treatment.

Tests cover fixed-width + string + null columns, `list_`/`large_list` (including null rows and lists of strings), struct/nested columns, pandas↔pyarrow equivalence, and numpy structured-record (`np.void`) cells in an object column.

**API note:** the return type changes from `list[int]` to `list[float]`, since sizes can now be fractional (bit-packed booleans, per-row bitmap shares). Sum before rounding. There are no other callers of this function in hats or hats-import outside the code updated here.

**Pylint note:** `pyarrow.compute` was added to `ignored-modules` in the pylintrc (alongside the existing `astropy.units`), because it builds its functions dynamically at import time, so pylint's static analysis can't see `binary_length`, `list_value_length`, `list_flatten`, or `struct_field` 

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation