### PR TITLE
Support signed and unsigned HEALPix indices in plot_healpix_map

### DIFF
--- a/src/hats/inspection/_plotting.py
+++ b/src/hats/inspection/_plotting.py
@@ -238,7 +238,7 @@ def _cull_from_pixel_map(depth_ipix_d: dict[int, tuple[np.ndarray, np.ndarray]],
         # split too large ipix into next order, with each child getting the same map value as parent
 
         too_large_child_ipix = np.repeat(too_large_ipix << 2, 4) + np.tile(
-            np.array([0, 1, 2, 3]), len(too_large_ipix)
+            np.arange(4, dtype=too_large_ipix.dtype), len(too_large_ipix)
         )
         too_large_child_vals = np.repeat(too_large_vals, 4)
 

--- a/src/hats/inspection/_plotting.py
+++ b/src/hats/inspection/_plotting.py
@@ -405,6 +405,10 @@ def _plot_healpix_value_map(ipix, depth, values, ax, wcs, cmap="viridis", norm=N
     depth_ipix_d = {}
     values = np.array(values)
     ipix = np.array(ipix)
+    if np.issubdtype(ipix.dtype, np.unsignedinteger):
+        ipix = ipix.astype(np.uint64, copy=False)
+    elif np.issubdtype(ipix.dtype, np.signedinteger):
+        ipix = ipix.astype(np.int64, copy=False)
 
     for d in np.unique(depth):
         mask = depth == d

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -131,6 +131,19 @@ def test_plot_healpix_pixels():
     assert ax.frame_class == EllipticalFrame
 
 
+@pytest.mark.parametrize("ipix_dtype", [np.int64, np.uint64])
+def test_plot_healpix_pixels_integer_ipix_dtypes(ipix_dtype):
+    pytest.importorskip("matplotlib.pyplot")
+
+    ipix = np.array([0], dtype=ipix_dtype)
+    pix_map = np.array([0.0])
+    depth = np.array([2], dtype=np.uint8)
+
+    _, ax = plot_healpix_map(pix_map, ipix=ipix, depth=depth, projection="MOL", cbar=False)
+
+    assert len(ax.collections) > 0
+
+
 def test_plot_healpix_pixels_different_order():
     pytest.importorskip("matplotlib.pyplot")
 

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -131,19 +131,6 @@ def test_plot_healpix_pixels():
     assert ax.frame_class == EllipticalFrame
 
 
-@pytest.mark.parametrize("ipix_dtype", [np.int64, np.uint64])
-def test_plot_healpix_pixels_integer_ipix_dtypes(ipix_dtype):
-    pytest.importorskip("matplotlib.pyplot")
-
-    ipix = np.array([0], dtype=ipix_dtype)
-    pix_map = np.array([0.0])
-    depth = np.array([2], dtype=np.uint8)
-
-    _, ax = plot_healpix_map(pix_map, ipix=ipix, depth=depth, projection="MOL", cbar=False)
-
-    assert len(ax.collections) > 0
-
-
 def test_plot_healpix_pixels_different_order():
     pytest.importorskip("matplotlib.pyplot")
 
@@ -205,12 +192,13 @@ def test_order_0_pixel_plots_with_step():
     np.testing.assert_array_equal(col.get_array(), np.full(length, fill_value=map_value))
 
 
-def test_edge_pixels_split_to_order_7():
+@pytest.mark.parametrize("ipix_dtype", [np.int8, np.uint8, np.int16, np.int64, np.uint64])
+def test_edge_pixels_split_to_order_7(ipix_dtype):
     pytest.importorskip("matplotlib.pyplot")
 
     map_value = 0.5
     order_0_pix = 2
-    ipix = np.array([order_0_pix])
+    ipix = np.array([order_0_pix], dtype=ipix_dtype)
     pix_map = np.array([map_value])
     depth = np.array([0])
     fig, ax = plot_healpix_map(pix_map, ipix=ipix, depth=depth)


### PR DESCRIPTION
## Change Description

Closes #703

`plot_healpix_map` raises a `TypeError` when it repeatedly splits a `uint64` HEALPix pixel. Mixed `uint64` and `int64` arithmetic promotes the child indices to `float64`, so the next bit shift fails. Preserving narrower integer dtypes can also cause overflow during repeated splitting.

## Solution Description

This change:

- Normalizes signed `ipix` arrays to `int64` and unsigned `ipix` arrays to `uint64` before plotting arithmetic.
- Generates child-pixel offsets with the normalized index dtype.
- Extends the order-0 edge-pixel regression test to cover `int8`, `uint8`, `int16`, `int64`, and `uint64` through order 7.

### Validation

- `pytest tests/hats/inspection/test_visualize_catalog.py -q` with NumPy 2.4.6: 38 passed.
- `pytest -q` with NumPy 2.5.2: 404 passed, 2 skipped.
- `pre-commit run --all-files`: passed.

## Code Quality

- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
