### PR TITLE
Fix local paths in generated collection HTML

### DIFF
--- a/src/hats/io/templates/collection_html_template.jinja2
+++ b/src/hats/io/templates/collection_html_template.jinja2
@@ -30,11 +30,11 @@ The following code provides a minimal example of opening this catalog:</p>
 <pre><code>import lsdb
 
 # Full sky coverage{% if has_default_columns %}, default columns only{% endif %}.
-catalog = lsdb.open_catalog("{{ uri or '&lt;PATH&gt;' }}")
+catalog = lsdb.open_catalog("{{ uri or '.' }}")
 {%- if cone_code_example %}
 # One-degree cone{% if has_default_columns %}, all columns{% endif %}.
 catalog = lsdb.open_catalog(
-    "{{ uri or '&lt;PATH&gt;' }}",
+    "{{ uri or '.' }}",
     search_filter=lsdb.ConeSearch(ra={{ cone_code_example["ra"] }}, dec={{ cone_code_example["dec"] }}, radius_arcsec=3600.0),
     {%- if has_default_columns %}
     columns="all",
@@ -53,7 +53,7 @@ catalog = lsdb.open_catalog(
 <h3>File structure</h3>
 <p>This catalog is represented by the following files and directories:</p>
 <ul>
-  <li><a href="{{uris["collection"]}}/collection.properties"><code>collection.properties</code></a> — textual metadata file describing the HATS collection of catalogs</li>
+  <li><a href="{{ uri or '.' }}/collection.properties"><code>collection.properties</code></a> — textual metadata file describing the HATS collection of catalogs</li>
   <li><a href="{{uris["primary"]["uri"]}}"><code>{{uris["primary"]["name"]}}</code></a> — main HATS catalog directory
     <ul>
       <li><a href="{{uris["primary"]["uri"]}}/dataset/"><code>dataset/</code></a> — Apache Parquet dataset directory for the main catalog

--- a/tests/hats/io/test_collection_html_local_path.py
+++ b/tests/hats/io/test_collection_html_local_path.py
@@ -1,0 +1,14 @@
+import shutil
+
+from hats.io.summary_file import write_catalog_summary_file
+
+
+def test_collection_html_uses_local_relative_path(tmp_path, small_sky_collection_dir):
+    collection_dir = tmp_path / "collection"
+    shutil.copytree(small_sky_collection_dir, collection_dir)
+
+    output_path = write_catalog_summary_file(collection_dir, fmt="html")
+
+    content = output_path.read_text()
+    assert 'lsdb.open_catalog(".")' in content
+    assert 'href="./collection.properties"' in content


### PR DESCRIPTION
Fixes #702. When no catalog URI is supplied, the collection HTML now uses the local relative path for both LSDB code examples and the collection.properties link. The Markdown placeholder behavior remains unchanged. Tests: python -m pytest tests/hats/io/test_summary_file.py tests/hats/io/test_collection_html_local_path.py -q (31 passed, 4 skipped). Formatting: Black and isort checks passed.