### PR TITLE
adding split_to_row_groups

### DIFF
--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -105,7 +105,6 @@ def _is_int_like(x):
     return isinstance(x, (int, np.integer))
 
 
-# TODO I'm not sure this is the best place for this, move?
 def split_to_row_groups(table: pa.Table, row_group_kwargs: dict | None, pixel_order: int | None = None):
     """Split the pixel table into its row group chunks according to the specified splitting strategy.
 

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from numbers import Integral
 
 import numpy as np

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 from numpy.typing import ArrayLike
 
 import hats.pixel_math.healpix_shim as hp
@@ -97,3 +98,44 @@ def healpix_to_spatial_index(
     pixel = np.int64(pixel)
     pixel_higher_order = pixel * (4 ** (spatial_index_order - order))
     return pixel_higher_order
+
+
+def split_to_row_groups(table, row_group_kwargs, pixel_order):
+    """Split the pixel table into its row group chunks according to the specified splitting strategy.
+
+    Parameters
+    ----------
+    table : pa.Table
+        Pixel table.
+    row_group_kwargs : dict
+        if "num_rows" (int >= 1) in row_group_kwargs, limit each chunk to a maximum of this many rows.
+            e.g. if the input table has 32 rows and num_rows == 10, then the chunks will have
+            [10, 10, 10, 2] rows.
+        if "subtile_order_delta" (int >= 0) in row_group_kwargs, create row groups corresponding to angular
+            proximity, approximated by HEALPix pixels.
+            If subtile_order_delta == 0, then each row group contains objects in the same HEALPix pixel of
+            order pixel_order. If subtile_order_delta == 1, then the row groups are split by HEALPix pixels
+            at order pixel_order + 1, etc. Higher numbers correspond to a finer grid (smaller pixels, fewer
+            rows per pixel).
+    pixel_order : int
+        The HEALPix order to split when using subtile_order_delta.
+
+    Returns
+    -------
+    split_tables : list[pa.Table]
+        The input table split into row group chunks.
+    """
+    if "num_rows" in row_group_kwargs:
+        chunk_size = row_group_kwargs["num_rows"]
+        return [table.slice(i, chunk_size) for i in range(0, len(table), chunk_size)]
+    if "subtile_order_delta" in row_group_kwargs:
+        split_tables = []
+        parent_pixels = table[SPATIAL_INDEX_COLUMN].to_numpy()
+        target_order = row_group_kwargs["subtile_order_delta"] + pixel_order
+        child_pixs = spatial_index_to_healpix(parent_pixels, target_order=target_order)
+        for child_pix in np.unique(child_pixs):
+            indices = np.where(child_pixs == child_pix)[0]
+            row_group = table.take(pa.array(indices))
+            split_tables.append(row_group)
+        return split_tables
+    return [table]

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -100,6 +100,11 @@ def healpix_to_spatial_index(
     return pixel_higher_order
 
 
+def _is_int_like(x):
+    """Return whether x is an int or a numpy integer."""
+    return isinstance(x, (int, np.integer))
+
+
 # TODO I'm not sure this is the best place for this, move?
 def split_to_row_groups(table: pa.Table, row_group_kwargs: dict | None, pixel_order: int | None = None):
     """Split the pixel table into its row group chunks according to the specified splitting strategy.
@@ -130,16 +135,16 @@ def split_to_row_groups(table: pa.Table, row_group_kwargs: dict | None, pixel_or
         return [table]
     if "num_rows" in row_group_kwargs:
         chunk_size = row_group_kwargs["num_rows"]
-        if not (isinstance(chunk_size, int) and (chunk_size >= 1)):
+        if not (_is_int_like(chunk_size) and (chunk_size >= 1)):
             raise ValueError("num_rows should be an integer >= 1")
         return [table.slice(i, chunk_size) for i in range(0, len(table), chunk_size)]
     if "subtile_order_delta" in row_group_kwargs:
         if not (
-            isinstance(row_group_kwargs["subtile_order_delta"], int)
+            _is_int_like(row_group_kwargs["subtile_order_delta"])
             and (row_group_kwargs["subtile_order_delta"] >= 0)
         ):
             raise ValueError("subtile_order_delta should be an integer >= 0")
-        if not (isinstance(pixel_order, int) and (pixel_order >= 0)):
+        if not (_is_int_like(pixel_order) and (pixel_order >= 0)):
             raise ValueError("pixel_order should be an integer >= 0")
         if SPATIAL_INDEX_COLUMN not in table.schema.names:
             raise ValueError(

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -1,3 +1,5 @@
+"""spatial_index.py: Utilities to convert between healpix coordinates and a scalar spatial index."""
+
 from __future__ import annotations
 
 from numbers import Integral
@@ -78,7 +80,8 @@ def healpix_to_spatial_index(
 ) -> np.int64 | np.ndarray:
     """Convert a healpix pixel to the healpix index
 
-    This maps the healpix pixel to the lowest pixel number within that pixel at the specified healpix order.
+    This maps the healpix pixel to the lowest pixel number within that pixel at the specified
+    healpix order.
 
     Useful for operations such as filtering by _healpix_29.
 
@@ -105,22 +108,24 @@ def healpix_to_spatial_index(
 def split_to_row_groups(
     table: pa.Table, row_group_kwargs: dict | None, pixel_order: int | None = None
 ) -> list[pa.Table]:
-    """Split the pixel table into its row group chunks according to the specified splitting strategy.
+    """Split the pixel table into row group chunks.
+    You can split by number of rows (num_rows), or by spatial proximity (subtile_order_delta).
 
     Parameters
     ----------
     table : pa.Table
         Pixel table.
     row_group_kwargs : dict
-        if "num_rows" (int >= 1) in row_group_kwargs, limit each chunk to a maximum of this many rows.
-            e.g. if the input table has 32 rows and num_rows == 10, then the chunks will have
-            [10, 10, 10, 2] rows.
-        if "subtile_order_delta" (int >= 0) in row_group_kwargs, create row groups corresponding to angular
-            proximity, approximated by HEALPix pixels.
-            If subtile_order_delta == 0, then each row group contains objects in the same HEALPix pixel of
-            order pixel_order. If subtile_order_delta == 1, then the row groups are split by HEALPix pixels
-            at order pixel_order + 1, etc. Higher numbers correspond to a finer grid (smaller pixels, fewer
-            rows per pixel).
+        if "num_rows" (int >= 1) in row_group_kwargs, limit each chunk to a maximum of
+            this many rows. e.g. if the input table has 32 rows and num_rows == 10,
+            then the chunks will have [10, 10, 10, 2] rows.
+        if "subtile_order_delta" (int >= 0) in row_group_kwargs, create row groups
+            corresponding to angular proximity, approximated by HEALPix pixels.
+            If subtile_order_delta == 0, then each row group contains objects in
+            the same HEALPix pixel of order pixel_order.
+            If subtile_order_delta == 1, then the row groups are split by HEALPix pixels
+            at order pixel_order + 1, etc.
+            Higher numbers correspond to a finer grid (smaller pixels, fewer rows per pixel).
     pixel_order : int | None
         The HEALPix order to split when using subtile_order_delta.
 
@@ -132,9 +137,8 @@ def split_to_row_groups(
     if (row_group_kwargs is None) or (row_group_kwargs == {}):
         return [table]
     if ("num_rows" in row_group_kwargs) and ("subtile_order_delta" in row_group_kwargs):
-        raise ValueError(
-            "row_group_kwargs contains conflicting keys. choose only one: num_rows or subtile_order_delta"
-        )
+        raise ValueError("row_group_kwargs contains conflicting keys. \
+                Choose only one: num_rows or subtile_order_delta")
     if "num_rows" in row_group_kwargs:
         chunk_size = row_group_kwargs["num_rows"]
         if not (isinstance(chunk_size, Integral) and (chunk_size >= 1)):
@@ -149,9 +153,8 @@ def split_to_row_groups(
         if not (isinstance(pixel_order, Integral) and (pixel_order >= 0)):
             raise ValueError("pixel_order should be an integer >= 0")
         if SPATIAL_INDEX_COLUMN not in table.schema.names:
-            raise ValueError(
-                "table has no spatial index column. You can generate one using compute_spatial_index()."
-            )
+            raise ValueError("table has no spatial index column. You can \
+                    generate one using compute_spatial_index().")
         split_tables = []
         parent_pixels = table[SPATIAL_INDEX_COLUMN].to_numpy()
         target_order = row_group_kwargs["subtile_order_delta"] + pixel_order
@@ -162,6 +165,5 @@ def split_to_row_groups(
             split_tables.append(row_group)
         return split_tables
     # no valid keys found
-    raise ValueError(
-        "no valid keys in row_group_kwargs. valid options are `num_rows` [int >= 1] or `subtile_order_delta` [int >= 0]."
-    )
+    raise ValueError("no valid keys in row_group_kwargs. valid options are \
+            `num_rows` [int >= 1] or `subtile_order_delta` [int >= 0].")

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -105,7 +105,9 @@ def _is_int_like(x):
     return isinstance(x, (int, np.integer))
 
 
-def split_to_row_groups(table: pa.Table, row_group_kwargs: dict | None, pixel_order: int | None = None):
+def split_to_row_groups(
+    table: pa.Table, row_group_kwargs: dict | None, pixel_order: int | None = None
+) -> list[pa.Table]:
     """Split the pixel table into its row group chunks according to the specified splitting strategy.
 
     Parameters

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -100,7 +100,8 @@ def healpix_to_spatial_index(
     return pixel_higher_order
 
 
-def split_to_row_groups(table, row_group_kwargs, pixel_order):
+# TODO I'm not sure this is the best place for this, move?
+def split_to_row_groups(table: pa.Table, row_group_kwargs: dict | None, pixel_order: int | None = None):
     """Split the pixel table into its row group chunks according to the specified splitting strategy.
 
     Parameters
@@ -117,7 +118,7 @@ def split_to_row_groups(table, row_group_kwargs, pixel_order):
             order pixel_order. If subtile_order_delta == 1, then the row groups are split by HEALPix pixels
             at order pixel_order + 1, etc. Higher numbers correspond to a finer grid (smaller pixels, fewer
             rows per pixel).
-    pixel_order : int
+    pixel_order : int | None
         The HEALPix order to split when using subtile_order_delta.
 
     Returns
@@ -125,10 +126,25 @@ def split_to_row_groups(table, row_group_kwargs, pixel_order):
     split_tables : list[pa.Table]
         The input table split into row group chunks.
     """
+    if (row_group_kwargs is None) or (row_group_kwargs == {}):
+        return [table]
     if "num_rows" in row_group_kwargs:
         chunk_size = row_group_kwargs["num_rows"]
+        if not (isinstance(chunk_size, int) and (chunk_size >= 1)):
+            raise ValueError("num_rows should be an integer >= 1")
         return [table.slice(i, chunk_size) for i in range(0, len(table), chunk_size)]
     if "subtile_order_delta" in row_group_kwargs:
+        if not (
+            isinstance(row_group_kwargs["subtile_order_delta"], int)
+            and (row_group_kwargs["subtile_order_delta"] >= 0)
+        ):
+            raise ValueError("subtile_order_delta should be an integer >= 0")
+        if not (isinstance(pixel_order, int) and (pixel_order >= 0)):
+            raise ValueError("pixel_order should be an integer >= 0")
+        if SPATIAL_INDEX_COLUMN not in table.schema.names:
+            raise ValueError(
+                "table has no spatial index column. You can generate one using compute_spatial_index()."
+            )
         split_tables = []
         parent_pixels = table[SPATIAL_INDEX_COLUMN].to_numpy()
         target_order = row_group_kwargs["subtile_order_delta"] + pixel_order

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -130,6 +130,10 @@ def split_to_row_groups(
     """
     if (row_group_kwargs is None) or (row_group_kwargs == {}):
         return [table]
+    if ("num_rows" in row_group_kwargs) and ("subtile_order_delta" in row_group_kwargs):
+        raise ValueError(
+            "row_group_kwargs contains conflicting keys. choose only one: num_rows or subtile_order_delta"
+        )
     if "num_rows" in row_group_kwargs:
         chunk_size = row_group_kwargs["num_rows"]
         if not (isinstance(chunk_size, Integral) and (chunk_size >= 1)):
@@ -156,4 +160,7 @@ def split_to_row_groups(
             row_group = table.take(pa.array(indices))
             split_tables.append(row_group)
         return split_tables
-    return [table]
+    # no valid keys found
+    raise ValueError(
+        "no valid keys in row_group_kwargs. valid options are `num_rows` [int >= 1] or `subtile_order_delta` [int >= 0]."
+    )

--- a/src/hats/pixel_math/spatial_index.py
+++ b/src/hats/pixel_math/spatial_index.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from numbers import Integral
 
 import numpy as np
 import pandas as pd
@@ -100,11 +101,6 @@ def healpix_to_spatial_index(
     return pixel_higher_order
 
 
-def _is_int_like(x):
-    """Return whether x is an int or a numpy integer."""
-    return isinstance(x, (int, np.integer))
-
-
 def split_to_row_groups(
     table: pa.Table, row_group_kwargs: dict | None, pixel_order: int | None = None
 ) -> list[pa.Table]:
@@ -136,16 +132,16 @@ def split_to_row_groups(
         return [table]
     if "num_rows" in row_group_kwargs:
         chunk_size = row_group_kwargs["num_rows"]
-        if not (_is_int_like(chunk_size) and (chunk_size >= 1)):
+        if not (isinstance(chunk_size, Integral) and (chunk_size >= 1)):
             raise ValueError("num_rows should be an integer >= 1")
         return [table.slice(i, chunk_size) for i in range(0, len(table), chunk_size)]
     if "subtile_order_delta" in row_group_kwargs:
         if not (
-            _is_int_like(row_group_kwargs["subtile_order_delta"])
+            isinstance(row_group_kwargs["subtile_order_delta"], Integral)
             and (row_group_kwargs["subtile_order_delta"] >= 0)
         ):
             raise ValueError("subtile_order_delta should be an integer >= 0")
-        if not (_is_int_like(pixel_order) and (pixel_order >= 0)):
+        if not (isinstance(pixel_order, Integral) and (pixel_order >= 0)):
             raise ValueError("pixel_order should be an integer >= 0")
         if SPATIAL_INDEX_COLUMN not in table.schema.names:
             raise ValueError(

--- a/tests/hats/pixel_math/test_spatial_index.py
+++ b/tests/hats/pixel_math/test_spatial_index.py
@@ -179,9 +179,13 @@ def test_split_to_row_groups():
     split_tables = split_to_row_groups(table, {}, None)
     assert [len(t) for t in split_tables] == [27]
 
-    # row_group_kwargs = {"unused": 1234}
-    split_tables = split_to_row_groups(table, {"unused": 1234}, None)
-    assert [len(t) for t in split_tables] == [27]
+    # row_group_kwargs contains only invalid keys
+    with pytest.raises(ValueError, match="no valid keys in row_group_kwargs"):
+        split_tables = split_to_row_groups(table, {"unused": 1234}, None)
+
+    # row_group_kwargs contains both valid and invalid keys
+    split_tables = split_to_row_groups(table, {"unused": 1234, "num_rows": 10}, None)
+    assert [len(t) for t in split_tables] == [10, 10, 7]
 
     # row_group_kwargs["num_rows"] == 10
     split_tables = split_to_row_groups(table, {"num_rows": 10}, None)
@@ -247,7 +251,6 @@ def test_split_to_row_groups():
     with pytest.raises(ValueError, match="table has no spatial index column"):
         split_tables = split_to_row_groups(table, {"subtile_order_delta": 0}, 0)
 
-    # row_group_kwargs["num_rows"] == 1 and row_group_kwargs["subtile_order_delta"] == 0
-    # (num_rows takes precedence over subtile_order_delta)
-    split_tables = split_to_row_groups(spatial_table, {"num_rows": 1, "subtile_order_delta": 0}, 0)
-    assert [len(t) for t in split_tables] == [1, 1, 1, 1]
+    # if both num_rows and subtile_order_delta present, raise ValueError
+    with pytest.raises(ValueError, match="row_group_kwargs contains conflicting keys"):
+        split_tables = split_to_row_groups(spatial_table, {"num_rows": 1, "subtile_order_delta": 0}, 0)

--- a/tests/hats/pixel_math/test_spatial_index.py
+++ b/tests/hats/pixel_math/test_spatial_index.py
@@ -2,14 +2,17 @@
 
 import numpy as np
 import numpy.testing as npt
+import pyarrow as pa
 import pytest
 
 import hats.pixel_math.healpix_shim as hp
 from hats.pixel_math.spatial_index import (
+    SPATIAL_INDEX_COLUMN,
     SPATIAL_INDEX_ORDER,
     compute_spatial_index,
     healpix_to_spatial_index,
     spatial_index_to_healpix,
+    split_to_row_groups,
 )
 
 
@@ -150,3 +153,104 @@ def test_healpix_to_spatial_index_array():
     actual_spatial_indices = compute_spatial_index(ra, dec)
     test_spatial_indices = healpix_to_spatial_index(orders, pixels)
     assert np.all(test_spatial_indices == actual_spatial_indices)
+
+
+def test_split_to_row_groups():
+    # table with no spatial index
+    table = pa.Table.from_arrays([[1.0] * 27], names=["data"])
+    # table with spatial index
+    # data | pixel index, order = (0, 1, 2)
+    # -----|-------------------------------
+    #  1.0 | (0, 0, 0)
+    #  2.0 | (0, 1, 4)
+    #  3.0 | (0, 2, 8)
+    #  4.0 | (0, 2, 9)
+    data = [1.0, 2.0, 3.0, 4.0]
+    orders = [2, 2, 2, 2]
+    pixels = [0, 4, 8, 9]
+    spatial_index = healpix_to_spatial_index(orders, pixels, spatial_index_order=SPATIAL_INDEX_ORDER)
+    spatial_table = pa.Table.from_arrays([data, spatial_index], names=["data", SPATIAL_INDEX_COLUMN])
+
+    # row_group_kwargs is None
+    split_tables = split_to_row_groups(table, None, None)
+    assert [len(t) for t in split_tables] == [27]
+
+    # row_group_kwargs = dict()
+    split_tables = split_to_row_groups(table, dict(), None)
+    assert [len(t) for t in split_tables] == [27]
+
+    # row_group_kwargs = {"unused": 1234}
+    split_tables = split_to_row_groups(table, {"unused": 1234}, None)
+    assert [len(t) for t in split_tables] == [27]
+
+    # row_group_kwargs["num_rows"] == 10
+    split_tables = split_to_row_groups(table, {"num_rows": 10}, None)
+    assert [len(t) for t in split_tables] == [10, 10, 7]
+
+    # row_group_kwargs["num_rows"] == 1000
+    split_tables = split_to_row_groups(table, {"num_rows": 1000}, None)
+    assert [len(t) for t in split_tables] == [27]
+
+    # row_group_kwargs["num_rows"] == 0
+    with pytest.raises(ValueError, match="num_rows should be an integer >= 1"):
+        split_tables = split_to_row_groups(table, {"num_rows": 0}, None)
+
+    # row_group_kwargs["num_rows"] < 0
+    with pytest.raises(ValueError, match="num_rows should be an integer >= 1"):
+        split_tables = split_to_row_groups(table, {"num_rows": -0}, None)
+
+    # row_group_kwargs["num_rows"] is not an integer
+    with pytest.raises(ValueError, match="num_rows should be an integer >= 1"):
+        split_tables = split_to_row_groups(table, {"num_rows": 0.123}, None)
+
+    # row_group_kwargs["subtile_order_delta"] < 0
+    with pytest.raises(ValueError, match="subtile_order_delta should be an integer >= 0"):
+        split_tables = split_to_row_groups(table, {"subtile_order_delta": -1}, None)
+
+    # row_group_kwargs["subtile_order_delta"] is not an integer
+    with pytest.raises(ValueError, match="subtile_order_delta should be an integer >= 0"):
+        split_tables = split_to_row_groups(table, {"subtile_order_delta": 0.123}, None)
+
+    # row_group_kwargs["subtile_order_delta"] == 0, pixel_order = 0
+    # rows split at order 0 => all rows in the same group
+    split_tables = split_to_row_groups(spatial_table, {"subtile_order_delta": 0}, 0)
+    assert [len(t) for t in split_tables] == [4]
+
+    # row_group_kwargs["subtile_order_delta"] == 0, pixel_order = 1
+    # rows split at order 1
+    split_tables = split_to_row_groups(spatial_table, {"subtile_order_delta": 0}, 1)
+    assert [len(t) for t in split_tables] == [1, 1, 2]
+
+    # row_group_kwargs["subtile_order_delta"] == 0, pixel_order = 2
+    # rows split at order 2
+    split_tables = split_to_row_groups(spatial_table, {"subtile_order_delta": 0}, 2)
+    assert [len(t) for t in split_tables] == [1, 1, 1, 1]
+
+    # row_group_kwargs["subtile_order_delta"] == 1, pixel_order = 0
+    # rows split at order 1
+    split_tables = split_to_row_groups(spatial_table, {"subtile_order_delta": 1}, 0)
+    assert [len(t) for t in split_tables] == [1, 1, 2]
+
+    # row_group_kwargs["subtile_order_delta"] == 0, pixel_order is None
+    with pytest.raises(ValueError, match="pixel_order should be an integer >= 0"):
+        split_tables = split_to_row_groups(spatial_table, {"subtile_order_delta": 0}, None)
+
+    # row_group_kwargs["subtile_order_delta"] == 0, pixel_order < 0
+    with pytest.raises(ValueError, match="pixel_order should be an integer >= 0"):
+        split_tables = split_to_row_groups(spatial_table, {"subtile_order_delta": 0}, -1)
+
+    # row_group_kwargs["subtile_order_delta"] == 0, pixel_order is not an integer
+    with pytest.raises(ValueError, match="pixel_order should be an integer >= 0"):
+        split_tables = split_to_row_groups(spatial_table, {"subtile_order_delta": 0}, 0.123)
+
+    # row_group_kwargs["subtile_order_delta"] == 0 but there's no spatial index column
+    with pytest.raises(ValueError, match="table has no spatial index column"):
+        split_tables = split_to_row_groups(table, {"subtile_order_delta": 0}, 0)
+
+    # row_group_kwargs["num_rows"] == 1 and row_group_kwargs["subtile_order_delta"] == 0
+    # (num_rows takes precedence over subtile_order_delta)
+    split_tables = split_to_row_groups(spatial_table, {"num_rows": 1, "subtile_order_delta": 0}, 0)
+    assert [len(t) for t in split_tables] == [1, 1, 1, 1]
+
+
+# TODO should probably add a test in test_parquet_metadata as well

--- a/tests/hats/pixel_math/test_spatial_index.py
+++ b/tests/hats/pixel_math/test_spatial_index.py
@@ -251,6 +251,3 @@ def test_split_to_row_groups():
     # (num_rows takes precedence over subtile_order_delta)
     split_tables = split_to_row_groups(spatial_table, {"num_rows": 1, "subtile_order_delta": 0}, 0)
     assert [len(t) for t in split_tables] == [1, 1, 1, 1]
-
-
-# TODO should probably add a test in test_parquet_metadata as well

--- a/tests/hats/pixel_math/test_spatial_index.py
+++ b/tests/hats/pixel_math/test_spatial_index.py
@@ -176,7 +176,7 @@ def test_split_to_row_groups():
     assert [len(t) for t in split_tables] == [27]
 
     # row_group_kwargs = dict()
-    split_tables = split_to_row_groups(table, dict(), None)
+    split_tables = split_to_row_groups(table, {}, None)
     assert [len(t) for t in split_tables] == [27]
 
     # row_group_kwargs = {"unused": 1234}


### PR DESCRIPTION
## Change Description
Moving `split_to_row_groups()` out of `hats-import` and into `hats`, because this function is needed by `lsdb` as well. See:
https://github.com/astronomy-commons/lsdb/pull/1519  
https://github.com/astronomy-commons/hats-import/pull/718

This PR must be merged before the above two.

## Solution Description
Moved `split_to_row_groups()` implementation from `hats-import` into `hats`, `spatial_index.py`. I'm not certain this is the best place for this function, but `split_to_row_groups` argument `subtile_order_delta` relies on the spatial index math, so this seemed like a good place.

I added error handling for edge cases, and tested each edge case.


## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
