### PR TITLE
Allow collections in plotting methods

### DIFF
--- a/HATS_GUIDE.md
+++ b/HATS_GUIDE.md
@@ -515,7 +515,7 @@ cat.plot_pixels()
 cat.plot_moc()
 
 # Plot point-density map
-hats.inspection.plot_density(cat)
+cat.plot_density()
 ```
 
 ### Filter by pixel or region

--- a/src/hats/catalog/catalog_collection.py
+++ b/src/hats/catalog/catalog_collection.py
@@ -93,6 +93,41 @@ class CatalogCollection:
         """The list of HEALPix pixels of the main catalog"""
         return self.main_catalog.get_healpix_pixels()
 
+    def plot_pixels(self, **kwargs):
+        """Create a visual map of the pixel density of the collection's main catalog.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional args to pass to `hats.inspection.visualize_catalog.plot_healpix_map`
+        """
+        return self.main_catalog.plot_pixels(**kwargs)
+
+    def plot_density(self, **kwargs):
+        """Create a visual map of the density of input points of the collection's main catalog.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional args to pass to `hats.inspection.visualize_catalog.plot_density`
+
+        Raises
+        ------
+        ValueError
+            if the main catalog is not on disk.
+        """
+        return self.main_catalog.plot_density(**kwargs)
+
+    def plot_moc(self, **kwargs):
+        """Create a visual map of the coverage of the collection's main catalog.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional args to pass to `hats.inspection.visualize_catalog.plot_moc`
+        """
+        return self.main_catalog.plot_moc(**kwargs)
+
     def get_margin_thresholds(self) -> dict[str, float]:
         """Get the margin thresholds for all margin catalogs in the collection.
 

--- a/src/hats/catalog/healpix_dataset/healpix_dataset.py
+++ b/src/hats/catalog/healpix_dataset/healpix_dataset.py
@@ -15,8 +15,7 @@ from hats.catalog.catalog_snapshot import CatalogSnapshot
 from hats.catalog.dataset import Dataset
 from hats.catalog.dataset.table_properties import TableProperties
 from hats.catalog.partition_info import PartitionInfo
-from hats.inspection import plot_pixels
-from hats.inspection.visualize_catalog import plot_moc
+from hats.inspection import plot_density, plot_moc, plot_pixels
 from hats.io import file_io, paths
 from hats.io.parquet_metadata import (
     aggregate_column_statistics,
@@ -294,6 +293,21 @@ class HealpixDataset(Dataset):
             Additional args to pass to `hats.inspection.visualize_catalog.plot_healpix_map`
         """
         return plot_pixels(self, **kwargs)
+
+    def plot_density(self, **kwargs):
+        """Create a visual map of the density of input points of the catalog on-disk.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional args to pass to `hats.inspection.visualize_catalog.plot_density`
+
+        Raises
+        ------
+        ValueError
+            if the catalog is not on disk.
+        """
+        return plot_density(self, **kwargs)
 
     def plot_moc(self, **kwargs):
         """Create a visual map of the coverage of the catalog.

--- a/src/hats/inspection/__init__.py
+++ b/src/hats/inspection/__init__.py
@@ -1,1 +1,1 @@
-from .visualize_catalog import plot_density, plot_pixel_list, plot_pixels
+from .visualize_catalog import plot_density, plot_moc, plot_pixel_list, plot_pixels

--- a/src/hats/inspection/visualize_catalog.py
+++ b/src/hats/inspection/visualize_catalog.py
@@ -5,6 +5,7 @@ NB: Testing validity of generated plots is currently not tested in our unit test
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Type
 
 import astropy.units as u
@@ -25,18 +26,25 @@ if TYPE_CHECKING:
     from matplotlib.colors import Colormap, Normalize
     from matplotlib.figure import Figure
 
-    from hats.catalog import Catalog
+    from hats.catalog import CatalogCollection
     from hats.catalog.healpix_dataset.healpix_dataset import HealpixDataset
 
 
 # pylint: disable=import-outside-toplevel,import-error
-def plot_density(catalog: Catalog, *, plot_title: str | None = None, order=None, unit=None, **kwargs):
+def plot_density(
+    catalog: HealpixDataset | CatalogCollection | None,
+    *,
+    plot_title: str | None = None,
+    order=None,
+    unit=None,
+    **kwargs,
+):
     """Create a visual map of the density of input points of a catalog on-disk.
 
     Parameters
     ----------
-    catalog: Catalog
-        on-disk catalog object
+    catalog: HealpixDataset | CatalogCollection | None
+        on-disk catalog object or collection
     plot_title : str | None
         Optional title for the plot
     order : int
@@ -58,8 +66,15 @@ def plot_density(catalog: Catalog, *, plot_title: str | None = None, order=None,
     except ImportError as exc:
         raise ImportError("matplotlib is required to use this method. Install with pip or conda.") from exc
 
+    from hats.catalog.catalog_collection import CatalogCollection
+
+    if isinstance(catalog, CatalogCollection):
+        catalog = catalog.main_catalog
     if catalog is None or not catalog.on_disk:
         raise ValueError("on disk catalog required for point-wise visualization")
+    if not catalog.unmodified:
+        logging.warning("Calling plot_density on a modified catalog. The plot may be inaccurate.")
+
     point_map = skymap.read_skymap(catalog, order)
     order = hp.npix2order(len(point_map))
 
@@ -84,18 +99,23 @@ def plot_density(catalog: Catalog, *, plot_title: str | None = None, order=None,
     return fig, ax
 
 
-def plot_pixels(catalog: HealpixDataset, plot_title: str | None = None, **kwargs):
+# pylint: disable=import-outside-toplevel
+def plot_pixels(catalog: HealpixDataset | CatalogCollection, plot_title: str | None = None, **kwargs):
     """Create a visual map of the pixel density of the catalog.
 
     Parameters
     ----------
     plot_title : str | None
         Optional title for the plot
-    catalog: HealpixDataset
-        on-disk or in-memory catalog, with healpix pixels.
+    catalog: HealpixDataset | CatalogCollection
+        on-disk or in-memory catalog, or collection, with healpix pixels.
     **kwargs
         Additional args to pass to `plot_healpix_map`
     """
+    from hats.catalog.catalog_collection import CatalogCollection
+
+    if isinstance(catalog, CatalogCollection):
+        catalog = catalog.main_catalog
     pixels = catalog.get_healpix_pixels()
     default_title = f"Catalog pixel map - {catalog.catalog_name}"
     title = default_title if plot_title is None else plot_title

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -1022,6 +1022,9 @@ def test_collection_plot_density(small_sky_collection_dir):
     _, ax = collection.plot_density()
     assert "Angular density of catalog small_sky_order1" == ax.get_title()
 
+    _, ax = plot_density(collection)
+    assert "Angular density of catalog small_sky_order1" == ax.get_title()
+
 
 def test_catalog_plot_density_errors(small_sky_source_dir):
     pytest.importorskip("matplotlib.pyplot")
@@ -1105,6 +1108,10 @@ def test_collection_plot_pixels(small_sky_collection_dir):
     collection = read_hats(small_sky_collection_dir)
     orders = [pixel.order for pixel in sorted(collection.get_healpix_pixels())]
     _, ax = collection.plot_pixels()
+    assert ax.get_title() == "Catalog pixel map - small_sky_order1"
+    np.testing.assert_array_equal(ax.collections[-1].get_array(), orders)
+
+    _, ax = plot_pixels(collection)
     assert ax.get_title() == "Catalog pixel map - small_sky_order1"
     np.testing.assert_array_equal(ax.collections[-1].get_array(), orders)
 

--- a/tests/hats/inspection/test_visualize_catalog.py
+++ b/tests/hats/inspection/test_visualize_catalog.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock
 
 import astropy.units as u
@@ -999,6 +1000,29 @@ def test_catalog_plot_density(small_sky_dir):
     assert len(order3_paths) < len(order10_paths)
 
 
+@pytest.mark.timeout(20)
+def test_catalog_plot_density_method(small_sky_dir):
+    """Test plotting pixel-density through the catalog method."""
+    pytest.importorskip("matplotlib.pyplot")
+
+    small_sky_catalog = read_hats(small_sky_dir)
+    _, ax = small_sky_catalog.plot_density()
+
+    assert "Angular density of catalog small_sky" == ax.get_title()
+    col = ax.collections[-1]
+    np.testing.assert_array_equal(col.get_edgecolors(), col.get_facecolors())
+
+
+@pytest.mark.timeout(20)
+def test_collection_plot_density(small_sky_collection_dir):
+    """Test plotting pixel-density for a collection, which plots its main catalog."""
+    pytest.importorskip("matplotlib.pyplot")
+
+    collection = read_hats(small_sky_collection_dir)
+    _, ax = collection.plot_density()
+    assert "Angular density of catalog small_sky_order1" == ax.get_title()
+
+
 def test_catalog_plot_density_errors(small_sky_source_dir):
     pytest.importorskip("matplotlib.pyplot")
 
@@ -1011,6 +1035,23 @@ def test_catalog_plot_density_errors(small_sky_source_dir):
 
     with pytest.raises(ValueError, match="catalog required"):
         plot_density(None)
+
+
+def test_catalog_plot_density_modified_catalog(small_sky_order1_catalog, small_sky_order1_pixels, caplog):
+    """Test that plotting the density of a modified catalog warns, as the skymap is read from disk."""
+    pytest.importorskip("matplotlib.pyplot")
+
+    filtered_catalog = small_sky_order1_catalog.filter_from_pixel_list(small_sky_order1_pixels[:1])
+    assert not filtered_catalog.unmodified
+
+    with caplog.at_level(logging.WARNING):
+        plot_density(filtered_catalog)
+    assert "modified catalog" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        plot_density(small_sky_order1_catalog)
+    assert caplog.text == ""
 
 
 def test_plot_pixels_empty_region_or_no_remaining():
@@ -1055,6 +1096,17 @@ def test_catalog_plot(small_sky_order1_catalog):
         np.testing.assert_array_equal(path.codes, codes)
     np.testing.assert_array_equal(col.get_array(), np.array([p.order for p in pixels]))
     assert ax.get_title() == f"Catalog pixel map - {small_sky_order1_catalog.catalog_name}"
+
+
+def test_collection_plot_pixels(small_sky_collection_dir):
+    """Test plotting pixels for a collection, which plots the pixels of its main catalog."""
+    pytest.importorskip("matplotlib.pyplot")
+
+    collection = read_hats(small_sky_collection_dir)
+    orders = [pixel.order for pixel in sorted(collection.get_healpix_pixels())]
+    _, ax = collection.plot_pixels()
+    assert ax.get_title() == "Catalog pixel map - small_sky_order1"
+    np.testing.assert_array_equal(ax.collections[-1].get_array(), orders)
 
 
 def test_catalog_plot_no_color_by_order(small_sky_order1_catalog):
@@ -1107,3 +1159,18 @@ def test_plot_moc_catalog(small_sky_order1_catalog):
     assert small_sky_order1_catalog.moc.fill.call_args[0][0] is ax
     wcs = ax.wcs
     assert small_sky_order1_catalog.moc.fill.call_args[0][1] is wcs
+
+
+def test_collection_plot_moc(small_sky_collection_dir):
+    """Test plotting the coverage of a collection, which plots the moc of its main catalog."""
+    pytest.importorskip("matplotlib.pyplot")
+
+    collection = read_hats(small_sky_collection_dir)
+    main_catalog_moc = collection.main_catalog.moc
+    main_catalog_moc.fill = MagicMock()
+    _, ax = collection.plot_moc()
+
+    main_catalog_moc.fill.assert_called_once()
+    assert main_catalog_moc.fill.call_args[0][0] is ax
+    assert main_catalog_moc.fill.call_args[0][1] is ax.wcs
+    assert ax.get_title() == "Coverage of small_sky_order1"


### PR DESCRIPTION
Allow collections in `plot_density`, `plot_moc` and `plot_pixels`, and adds their wrappers to the `HealpixDataset` and `CatalogCollection` classes. Closes #698. 
