### PR TITLE
Fix precision loss in `HealpixPixel.dir` for large pixel indices

### DIFF
--- a/src/hats/pixel_math/healpix_pixel.py
+++ b/src/hats/pixel_math/healpix_pixel.py
@@ -101,7 +101,7 @@ class HealpixPixel:
 
             (pixel_number/10000)*10000
         """
-        return int(self.pixel / 10_000) * 10_000
+        return (self.pixel // 10_000) * 10_000
 
 
 INVALID_PIXEL = HealpixPixel(-1, -1)

--- a/tests/hats/pixel_math/test_healpix_pixel.py
+++ b/tests/hats/pixel_math/test_healpix_pixel.py
@@ -107,6 +107,13 @@ def test_convert_higher_order_fails_above_limit():
         pixel.convert_to_higher_order(SPATIAL_INDEX_ORDER - order + 1)
 
 
+def test_dir_large_pixel_no_precision_loss():
+    # At order 29, pixel indices can reach ~3.5e18, which loses precision
+    # when routed through float division.
+    healpix_pixel = HealpixPixel(order=29, pixel=1243412673254409927)
+    assert healpix_pixel.dir == 1243412673254400000
+
+
 def test_convert_higher_order_fails_negative():
     order = 4
     pixel = 3


### PR DESCRIPTION
Fix of a bug, which is practically looks impossible to happen, but it still makes code cleaner. Discovered with a local model as a part of the experiment or asking it "fix a bug".